### PR TITLE
chore: fix redeemable

### DIFF
--- a/src/lib/vega-web3-types.ts
+++ b/src/lib/vega-web3-types.ts
@@ -44,4 +44,5 @@ export interface TrancheUser {
 export enum TrancheEvents {
   Created = "Tranche_Created",
   BalanceAdded = "Tranche_Balance_Added",
+  BalanceRemoved = "Tranche_Balance_Removed",
 }

--- a/src/lib/vega-web3.ts
+++ b/src/lib/vega-web3.ts
@@ -137,7 +137,7 @@ class VegaWeb3 {
         );
         const balanceRemovedEvents = events.filter(
           (e) =>
-            e.event === TrancheEvents.BalanceAdded &&
+            e.event === TrancheEvents.BalanceRemoved &&
             e.returnValues.tranche_id === tranche_id
         );
 
@@ -150,7 +150,6 @@ class VegaWeb3 {
         // get added and removed values
         const total_added = this.sumFromEvents(balanceAddedEvents);
         const total_removed = this.sumFromEvents(balanceRemovedEvents);
-
         // get locked amount
         const locked_amount = this.getLockedAmount(
           total_added,


### PR DESCRIPTION
Redeemable was 0 because we accidentally used the wrong event type in the refactor. This PR fixes that: 

<img width="1792" alt="Screenshot 2021-07-28 at 22 18 07" src="https://user-images.githubusercontent.com/26136207/127397341-435de36e-475e-491a-9a56-9953588226b2.png">
