### PR TITLE
Update document title (tab title) for each page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;500&display=swap"
       rel="stylesheet"
     />
-    <title>Vega Protocol - VEGA Token Vesting</title>
+    <title>VEGA Token</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/hooks/use-document-title.ts
+++ b/src/hooks/use-document-title.ts
@@ -1,0 +1,13 @@
+import React from "react";
+
+export function useDocumentTitle(name?: string) {
+  const base = "VEGA token";
+
+  React.useEffect(() => {
+    if (name) {
+      document.title = `${base} | ${name}`;
+    } else {
+      document.title = base;
+    }
+  }, [name]);
+}

--- a/src/routes/claim/index.tsx
+++ b/src/routes/claim/index.tsx
@@ -16,8 +16,11 @@ import { Web3Container } from "../../components/web3-container";
 import { ClaimConnect } from "./claim-connect";
 import { TrancheContainer } from "../../components/tranche-container";
 import { WrongChain } from "../../components/wrong-chain";
+import { RouteChildProps } from "..";
+import { useDocumentTitle } from "../../hooks/use-document-title";
 
-const Claim = () => {
+const Claim = ({ name }: RouteChildProps) => {
+  useDocumentTitle(name);
   const { t } = useTranslation();
   const params = useSearchParams();
   const { appState, appDispatch } = useAppState();

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,6 +4,10 @@ import { SplashLoader } from "../components/splash-loader";
 import { SplashScreen } from "../components/splash-screen";
 import routerConfig from "./router-config";
 
+export interface RouteChildProps {
+  name: string;
+}
+
 export const AppRouter = () => {
   const splashLoading = (
     <SplashScreen>
@@ -16,7 +20,9 @@ export const AppRouter = () => {
       <Switch>
         {routerConfig.map(
           ({ path, component: Component, exact = false, name }) => (
-            <Route key={name} path={path} exact={exact} component={Component} />
+            <Route key={name} path={path} exact={exact}>
+              <Component name={name} />
+            </Route>
           )
         )}
       </Switch>

--- a/src/routes/no-provider/index.tsx
+++ b/src/routes/no-provider/index.tsx
@@ -1,12 +1,15 @@
 import { useTranslation } from "react-i18next";
 import { Redirect } from "react-router-dom";
+import { RouteChildProps } from "..";
 import { DefaultTemplate } from "../../components/page-templates/default";
 import {
   ProviderStatus,
   useAppState,
 } from "../../contexts/app-state/app-state-context";
+import { useDocumentTitle } from "../../hooks/use-document-title";
 
-const NoProvider = () => {
+const NoProvider = ({ name }: RouteChildProps) => {
+  useDocumentTitle(name);
   const { t } = useTranslation();
   const {
     appState: { providerStatus },

--- a/src/routes/not-found/index.tsx
+++ b/src/routes/not-found/index.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from "react-i18next";
+import { RouteChildProps } from "..";
 import { DefaultTemplate } from "../../components/page-templates/default";
+import { useDocumentTitle } from "../../hooks/use-document-title";
 
-const NotFound = () => {
+const NotFound = ({ name }: RouteChildProps) => {
+  useDocumentTitle(name);
   const { t } = useTranslation();
   return (
     <DefaultTemplate title={t("pageTitle404")}>

--- a/src/routes/not-permitted/index.tsx
+++ b/src/routes/not-permitted/index.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from "react-i18next";
+import { RouteChildProps } from "..";
 import { DefaultTemplate } from "../../components/page-templates/default";
+import { useDocumentTitle } from "../../hooks/use-document-title";
 
-const NotPermitted = () => {
+const NotPermitted = ({ name }: RouteChildProps) => {
+  useDocumentTitle(name);
   const { t } = useTranslation();
   return (
     <DefaultTemplate title={t("pageTitleNotPermitted")}>

--- a/src/routes/redemption/index.tsx
+++ b/src/routes/redemption/index.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { RouteChildProps } from "..";
 import { DefaultTemplate } from "../../components/page-templates/default";
+import { useDocumentTitle } from "../../hooks/use-document-title";
 
-const RedemptionRouter = () => {
+const RedemptionRouter = ({ name }: RouteChildProps) => {
+  useDocumentTitle(name);
   const { t } = useTranslation();
   return (
     <DefaultTemplate title={t("pageTitleRedemption")}>

--- a/src/routes/tranches/index.tsx
+++ b/src/routes/tranches/index.tsx
@@ -5,8 +5,11 @@ import { DefaultTemplate } from "../../components/page-templates/default";
 import { useTranslation } from "react-i18next";
 import { Web3Container } from "../../components/web3-container";
 import { TrancheContainer } from "../../components/tranche-container";
+import { useDocumentTitle } from "../../hooks/use-document-title";
+import { RouteChildProps } from "..";
 
-const TrancheRouter = () => {
+const TrancheRouter = ({ name }: RouteChildProps) => {
+  useDocumentTitle(name);
   const { t } = useTranslation();
 
   return (


### PR DESCRIPTION
As per title

- Pages now have the name property of the their configuration object passed to them as a prop
- Adds a useDocumentTitle hook to update the document title if the props changes.  Will default to just VEGA Token. If not used for a page

Closes #154 