### PR TITLE
Tidy up headers

### DIFF
--- a/src/components/bullet-header/bullet-header.tsx
+++ b/src/components/bullet-header/bullet-header.tsx
@@ -4,8 +4,13 @@ import React from "react";
 interface BulletHeaderProps {
   tag: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   children: React.ReactNode;
+  style?: React.CSSProperties;
 }
 
-export const BulletHeader = ({ tag, children }: BulletHeaderProps) => {
-  return React.createElement(tag, { className: "bullet-header" }, children);
+export const BulletHeader = ({ tag, children, style }: BulletHeaderProps) => {
+  return React.createElement(
+    tag,
+    { className: "bullet-header", style },
+    children
+  );
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -38,6 +38,9 @@ h4,
 h5,
 h6 {
   color: $white;
+  font-weight: 500;
+  margin-top: 1em;
+  margin-bottom: 15px;
 }
 
 p {

--- a/src/routes/redemption/home/redemption-information.tsx
+++ b/src/routes/redemption/home/redemption-information.tsx
@@ -90,7 +90,7 @@ export const RedemptionInformation = ({
         locked={totalLockedBalance}
         vested={totalVestedBalance}
       />
-      {filteredTranches.length ? <h1>{t("Tranche breakdown")}</h1> : null}
+      {filteredTranches.length ? <h2>{t("Tranche breakdown")}</h2> : null}
       {filteredTranches.map((tr) => (
         <TrancheTable
           key={tr.tranche_id}

--- a/src/routes/redemption/home/vesting-table.tsx
+++ b/src/routes/redemption/home/vesting-table.tsx
@@ -29,7 +29,7 @@ export const VestingTable = ({ vested, locked, staked }: VestingTableProps) => {
   }, [total, staked]);
   return (
     <section data-testid="vesting-table" className="vesting-table">
-      <h1>{t("Across all tranches")}</h1>
+      <h2>{t("Across all tranches")}</h2>
       <KeyValueTable numerical={true}>
         <KeyValueTableRow
           data-testid="vesting-table-total"

--- a/src/routes/redemption/tranche-table.scss
+++ b/src/routes/redemption/tranche-table.scss
@@ -1,7 +1,6 @@
 @import "../../styles/colors";
 
 .tranche-table {
-  margin-top: 30px;
   margin-bottom: 30px;
 
   &__label {

--- a/src/routes/tranches/tranches.tsx
+++ b/src/routes/tranches/tranches.tsx
@@ -25,7 +25,9 @@ export const Tranches = ({ tranches }: { tranches: Tranche[] }) => {
 
   return (
     <>
-      <BulletHeader tag="h2">{t("Tranches")}</BulletHeader>
+      <BulletHeader tag="h2" style={{ marginTop: 0 }}>
+        {t("Tranches")}
+      </BulletHeader>
       {tranches?.length ? (
         <ul className="tranches__list">
           {(showAll ? tranches : filteredTranches).map((tranche) => {


### PR DESCRIPTION
Minor css html changes to improve look and feel and accessibility 

- Reduce header font weight
- Make headers on redemption page h2s (page title is the h1)
- Align tranche pages title to top of container
- Remove margin from tranche table so spacing is consistent