### PR TITLE
Show more correct error when an old web3 is detected

### DIFF
--- a/src/components/web3-container/web3-container.tsx
+++ b/src/components/web3-container/web3-container.tsx
@@ -20,9 +20,16 @@ export const Web3Container = ({
   const connect = useConnect();
 
   if (appState.providerStatus === ProviderStatus.None) {
+    let error: string
+    // @ts-ignore
+    if (window?.web3?.currentProvider && !window.web3.currentProvider.request) {
+      error = t("invalidWeb3Provider")
+    } else {
+      error = t("invalidWeb3Browser")
+    }
     return (
       <Callout title={t("Cannot connect")} intent="error" icon={<Error />}>
-        <p>{t("invalidWeb3Browser")}</p>
+        <p>{error}</p>
       </Callout>
     );
   }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -79,6 +79,7 @@ const en = {
   codeExpired: "Code expired",
 
   invalidWeb3Browser: "You need a web3 capable browser to use this site",
+  invalidWeb3Provider: "Incompatible web3 provider detected. Please try another browser / extension.",
   "Vesting Balance": "Vesting Balance",
   VEGA: "VEGA",
   Account: "Account",


### PR DESCRIPTION
Nice to have:

Show a better error for people who think Opera is going to be a sufficient web3 provider. It should be, but we use web3.request a lot - as we should - and it's not available as the provider we're getting in Opera desktop doesn't have it. We can investigate better support later - for now suggest an alternative.

- Add new i18n string for incompatible web3 provider
- Add more specific error if web3 exists, but web3.request does not

Closes #189
