### PR TITLE
hacky fix for number rendering

### DIFF
--- a/src/lib/bignumber.ts
+++ b/src/lib/bignumber.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
 
-BigNumber.config({ EXPONENTIAL_AT: 20 });
+BigNumber.config({ EXPONENTIAL_AT: 20000 });
 
 export { BigNumber };


### PR DESCRIPTION
Hacky fix to get us going.

More generally this is bad becuase of our way of using BigNumber in the store. There is seperate ticket tracking for that but wasn't a change we wanted to do yesterday.

This is enough to handle wayyy more vega that is possible to exist so should do as an interim solution.

Sentry issue: https://sentry.io/organizations/vega-o3/issues/2622248164/?environment=production&project=5882996&query=is%3Aunresolved+user.id%3A0xab6de081af6c78433afdac5b756804bce17e9ec1&statsPeriod=14d