### PR TITLE
Remove handling of slash in node id. Get node id from useParams

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -24,6 +24,11 @@ export function createClient() {
       Node: {
         keyFields: false,
       },
+      NodeData: {
+        merge: (existing = {}, incoming) => {
+          return { ...existing, ...incoming };
+        },
+      },
     },
   });
 

--- a/src/routes/staking/staking-node.tsx
+++ b/src/routes/staking/staking-node.tsx
@@ -1,7 +1,7 @@
 import "./staking-node.scss";
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { ValidatorTable } from "./validator-table";
 import { VegaKeyExtended } from "../../contexts/app-state/app-state-context";
 import { EpochCountdown } from "./epoch-countdown";
@@ -69,9 +69,7 @@ interface StakingNodeProps {
 }
 
 export const StakingNode = ({ vegaKey }: StakingNodeProps) => {
-  // TODO: Remove and get id via useParams. Eg:
-  // const node = useParams<{ node: string }>()
-  const node = TEMP_useNodeIdFromLocation();
+  const { node } = useParams<{ node: string }>();
   const { t } = useTranslation();
   const { data, loading, error } = useQuery<StakeNode, StakeNodeVariables>(
     STAKE_NODE_QUERY,
@@ -136,16 +134,3 @@ export const StakingNode = ({ vegaKey }: StakingNodeProps) => {
     </>
   );
 };
-
-// Hook to get the node id from the url. We need this because currently
-// the ides contain slashes which means the paths dont correctly match in
-// react router.
-function TEMP_useNodeIdFromLocation() {
-  const location = useLocation();
-  const regex = /\/staking\/(.+)$/;
-  const res = regex.exec(location.pathname);
-  if (res) {
-    return res[1];
-  }
-  return "";
-}


### PR DESCRIPTION
- As per title, we can now use useParams to get the node if from the url
- Also fixed a cache merge issue by adding a merge function for type NodeData.