### PR TITLE
Feat/348 Styles for geo blocked page

### DIFF
--- a/public/blocked/index.html
+++ b/public/blocked/index.html
@@ -1,7 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/png" href="../favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Vega Protocol - VEGA Token Vesting" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <title>VEGA Token</title>
+    <style>
+      html,
+      body {
+        font-family: "Helvetica neue", Helvetica, arial, sans-serif;
+        color: #fff;
+        background-color: #000;
+        height: 100%;
+        margin: 0;
+      }
+
+      body > div {
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    </style>
+  </head>
   <body>
-    <p>This page is unavailable in your region</p>
+    <div class="center">
+      <p>This page is unavailable in your region</p>
+    </div>
     <script>
       var date = new Date();
       date.setTime(date.getTime() + 30 * 24 * 60 * 60 * 1000);


### PR DESCRIPTION
Adds basic styles for the geo fenced page. I've made it look the same as the 'wrong chain' and 'no provider' pages which seemed suitable for now.

<img width="1028" alt="Screenshot 2021-09-03 at 15 46 50" src="https://user-images.githubusercontent.com/6803987/132071989-f91470ec-475a-44fa-90f2-3ed5562e5baa.png">

#348 