### PR TITLE
Fix vesting page stuck in loading state if no tranches balances

### DIFF
--- a/src/routes/redemption/redemption.tsx
+++ b/src/routes/redemption/redemption.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Route, Switch, useRouteMatch } from "react-router-dom";
+import { Callout } from "../../components/callout";
 import { EthConnectPrompt } from "../../components/eth-connect-prompt";
 import { SplashLoader } from "../../components/splash-loader";
 import { SplashScreen } from "../../components/splash-screen";
@@ -16,6 +18,7 @@ import {
 import { RedeemFromTranche } from "./tranche";
 
 const RedemptionRouter = () => {
+  const { t } = useTranslation();
   const match = useRouteMatch();
   const vesting = useVegaVesting();
   const [state, dispatch] = React.useReducer(
@@ -46,11 +49,19 @@ const RedemptionRouter = () => {
     }
   }, [ethAddress, tranches, vesting]);
 
-  if (!tranches.length || !trancheBalances.length) {
+  if (!tranches.length) {
     return (
       <SplashScreen>
         <SplashLoader />
       </SplashScreen>
+    );
+  }
+
+  if (!trancheBalances.length) {
+    return (
+      <Callout>
+        <p>{t("You have no VEGA tokens currently vesting.")}</p>
+      </Callout>
     );
   }
 


### PR DESCRIPTION
If you have an eth address which has 0 vesting tokens you get stuck in a perpetual loading state. This instead shows a message that you don't have any vesting VEGA tokens.