### PR TITLE
Remove inline styles from token-input

### DIFF
--- a/src/components/token-input/token-input.scss
+++ b/src/components/token-input/token-input.scss
@@ -1,6 +1,10 @@
 @import "../../styles/colors";
 
 .token-input {
+  &__container {
+    display: flex;
+  }
+
   &__input {
     flex: 1;
   }
@@ -16,5 +20,9 @@
 
   &__approved {
     margin-top: 25px;
+  }
+
+  &__submit {
+    margin-top: 10px;
   }
 }

--- a/src/components/token-input/token-input.tsx
+++ b/src/components/token-input/token-input.tsx
@@ -53,7 +53,7 @@ export const TokenInput = ({
   }, [amount, isApproved, maximum, requireApproval]);
   return (
     <FormGroup label="" labelFor={inputName}>
-      <div style={{ display: "flex" }}>
+      <div className="token-input__container">
         <InputGroup
           data-testid="token-amount-input"
           className="token-input__input"
@@ -84,17 +84,15 @@ export const TokenInput = ({
       ) : (
         <button
           data-testid="token-input-approve-button"
-          className="fill"
-          style={{ marginTop: 10 }}
+          className="fill token-input__submit"
           onClick={approve}
         >
           {approveText}
         </button>
       )}
       <button
-        style={{ marginTop: 10 }}
-        className="fill"
         data-testid="token-input-submit-button"
+        className="fill token-input__submit"
         disabled={isDisabled}
         onClick={perform}
       >


### PR DESCRIPTION
Removes two inline styles from token-input, moving them to scss

Closes #407