### PR TITLE
Truncate node id

### DIFF
--- a/src/components/vega-wallet/vega-wallet.tsx
+++ b/src/components/vega-wallet/vega-wallet.tsx
@@ -26,6 +26,7 @@ import {
 import { useVegaUser } from "../../hooks/use-vega-user";
 import { useVegaVesting } from "../../hooks/use-vega-vesting";
 import { BigNumber } from "../../lib/bignumber";
+import {truncateMiddle} from "../../lib/truncate-middle";
 
 const DELEGATIONS_QUERY = gql`
   query Delegations($partyId: ID!) {
@@ -215,7 +216,7 @@ const VegaWalletConnected = ({
       ) : null}
       {delegations.map((d) => (
         <WalletCardRow
-          label={d.node.id}
+          label={truncateMiddle(d.node.id)}
           value={new BigNumber(d.amount)}
           valueSuffix={t("VEGA")}
         />


### PR DESCRIPTION
Truncate node ID in wallet overview.

Before:
![Screenshot from 2021-09-17 18-29-21](https://user-images.githubusercontent.com/6678/133832653-91c88c9b-b77b-4bd3-9845-0b26905f5294.png)

After: 

![Screenshot from 2021-09-17 18-55-05](https://user-images.githubusercontent.com/6678/133832773-4560341c-d769-41fe-b961-e01ebfcc555a.png)
![Screenshot from 2021-09-17 18-54-45](https://user-images.githubusercontent.com/6678/133832777-cf200385-9152-4091-b8de-4fd84c2b51b9.png)



See #448. Doesn't close it, but we might not address this if #438 fixes number formatting
