### PR TITLE
Add tokens to mm

### DIFF
--- a/src/components/add-token-button/add-token-button.scss
+++ b/src/components/add-token-button/add-token-button.scss
@@ -1,0 +1,10 @@
+@import "../../styles/colors";
+
+.add-token-button {
+  img {
+    width: 32px;
+    height: 32px;
+    border: 1px solid $white;
+    border-radius: 2px;
+  }
+}

--- a/src/components/add-token-button/add-token-button.scss
+++ b/src/components/add-token-button/add-token-button.scss
@@ -2,8 +2,6 @@
 
 .add-token-button {
   img {
-    width: 32px;
-    height: 32px;
     border: 1px solid $white;
     border-radius: 2px;
   }

--- a/src/components/add-token-button/add-token-button.tsx
+++ b/src/components/add-token-button/add-token-button.tsx
@@ -6,18 +6,16 @@ export const AddTokenButton = ({
   symbol,
   decimals,
   image,
-  buttonImage,
 }: {
   address: string;
   symbol: string;
   decimals: number;
   image: string;
-  buttonImage: string;
 }) => {
   const addToken = useAddAssetToWallet(address, symbol, decimals, image);
   return (
     <button className="add-token-button button-link" onClick={addToken}>
-      <img alt="token-logo" src={buttonImage} />
+      <img alt="token-logo" src={image} />
     </button>
   );
 };

--- a/src/components/add-token-button/add-token-button.tsx
+++ b/src/components/add-token-button/add-token-button.tsx
@@ -6,16 +6,18 @@ export const AddTokenButton = ({
   symbol,
   decimals,
   image,
+  size = 32,
 }: {
   address: string;
   symbol: string;
   decimals: number;
   image: string;
+  size?: number;
 }) => {
   const addToken = useAddAssetToWallet(address, symbol, decimals, image);
   return (
     <button className="add-token-button button-link" onClick={addToken}>
-      <img alt="token-logo" src={image} />
+      <img style={{ width: size, height: size }} alt="token-logo" src={image} />
     </button>
   );
 };

--- a/src/components/add-token-button/add-token-button.tsx
+++ b/src/components/add-token-button/add-token-button.tsx
@@ -1,0 +1,23 @@
+import "./add-token-button.scss";
+import { useAddAssetToWallet } from "../../hooks/use-add-asset-to-wallet";
+
+export const AddTokenButton = ({
+  address,
+  symbol,
+  decimals,
+  image,
+  buttonImage,
+}: {
+  address: string;
+  symbol: string;
+  decimals: number;
+  image: string;
+  buttonImage: string;
+}) => {
+  const addToken = useAddAssetToWallet(address, symbol, decimals, image);
+  return (
+    <button className="add-token-button button-link" onClick={addToken}>
+      <img alt="token-logo" src={buttonImage} />
+    </button>
+  );
+};

--- a/src/components/add-token-button/index.tsx
+++ b/src/components/add-token-button/index.tsx
@@ -1,0 +1,1 @@
+export { AddTokenButton } from "./add-token-button";

--- a/src/hooks/use-add-asset-to-wallet.ts
+++ b/src/hooks/use-add-asset-to-wallet.ts
@@ -1,0 +1,35 @@
+import React from "react";
+import { useAppState } from "../contexts/app-state/app-state-context";
+
+export const useAddAssetToWallet = (
+  address: string,
+  symbol: string,
+  decimals: number,
+  image: string
+) => {
+  const { provider } = useAppState();
+  return React.useCallback(async () => {
+    try {
+      const wasAdded = await provider.request({
+        method: "wallet_watchAsset",
+        params: {
+          type: "ERC20",
+          options: {
+            address,
+            symbol,
+            decimals,
+            image,
+          },
+        },
+      });
+
+      if (wasAdded) {
+        console.log("Thanks for your interest!");
+      } else {
+        console.log("Your loss!");
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }, [address, decimals, image, provider, symbol]);
+};

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -19,6 +19,7 @@ const en = {
   Vesting: "Vesting",
   of: "of",
   to: "to",
+  Or: "Or",
   Deposit: "deposit",
   Tranche: "Tranche",
   Tranches: "Tranches",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -472,7 +472,7 @@ const en = {
   liquidityTokenApprove: "Approve",
   liquidityComingSoon: "Liquidity rewards coming soon",
   "Keep track of locked tokens in your wallet with the VEGA (VESTING) token.":
-    "Keep track of locked tokens in your wallet with the VEGA (VESTING) token.",
+    "Keep track of locked tokens in your wallet with the VEGA-Locked token by clicking the button below:",
   "The token address is {{address}}. Hit the add token button in your ERC20 wallet and enter this address.":
     "The token address is {{address}}. Hit the add token button in your ERC20 wallet and enter this address.",
   mainnetDisableHome:

--- a/src/lib/vega-web3/vega-lp-staking.ts
+++ b/src/lib/vega-web3/vega-lp-staking.ts
@@ -125,6 +125,12 @@ export default class VegaLPStaking implements IVegaLPStaking {
     return awardContract._address as string;
   }
 
+  async lpTokenAddress() {
+    const lpContract = await this.lpContract;
+    // @ts-ignore // Contract._address is private
+    return lpContract._address as string;
+  }
+
   async rewardPerEpoch(): Promise<BigNumber> {
     const rewardPerEpoch = await this.contract.methods.epoch_reward().call();
     const decimals = await this.awardDecimals;

--- a/src/lib/web3-utils.ts
+++ b/src/lib/web3-utils.ts
@@ -194,15 +194,14 @@ export interface IVegaToken {
 }
 
 export interface IVegaLPStaking {
-  stakedBalance(
-    account: string
-  ): Promise<{
+  stakedBalance(account: string): Promise<{
     pending: BigNumber;
     earningRewards: BigNumber;
     total: BigNumber;
   }>;
   rewardsBalance(account: string): Promise<BigNumber>;
   awardContractAddress(): Promise<string>;
+  lpTokenAddress(): Promise<string>;
   rewardPerEpoch(): Promise<BigNumber>;
   estimateAPY(): Promise<BigNumber>;
   totalStaked(): Promise<BigNumber>;

--- a/src/routes/claim/code-used.scss
+++ b/src/routes/claim/code-used.scss
@@ -1,0 +1,15 @@
+.or {
+  display: flex;
+  margin: 12px 0px;
+
+  hr {
+    flex: 1;
+    margin-top: 12px;
+    &:first-child {
+      margin-right: 12px;
+    }
+    &:last-child {
+      margin-left: 12px;
+    }
+  }
+}

--- a/src/routes/claim/code-used.tsx
+++ b/src/routes/claim/code-used.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { AddTokenButton } from "../../components/add-token-button";
 import { Callout } from "../../components/callout";
 import { Error } from "../../components/icons";
 import { ADDRESSES } from "../../config";
@@ -13,6 +14,21 @@ export const CodeUsed = ({ address }: { address: string | null }) => {
           "Keep track of locked tokens in your wallet with the VEGA (VESTING) token."
         )}
       </h4>
+      <p style={{ display: "flex", justifyContent: "center" }}>
+        <AddTokenButton
+          size={64}
+          address={ADDRESSES.lockedAddress}
+          symbol="VEGA-Locked"
+          decimals={18}
+          image={
+            "https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
+          }
+        />
+      </p>
+      <div style={{ display: "flex ", margin: "12px 0px" }}>
+        <hr style={{ flex: 1, marginRight: 12, marginTop: 12 }} />
+        Or <hr style={{ flex: 1, marginLeft: 12, marginTop: 12 }} />
+      </div>
       <p>
         {t(
           "The token address is {{address}}. Hit the add token button in your ERC20 wallet and enter this address.",

--- a/src/routes/claim/code-used.tsx
+++ b/src/routes/claim/code-used.tsx
@@ -1,3 +1,4 @@
+import "./code-used.scss";
 import { useTranslation } from "react-i18next";
 import { AddTokenButton } from "../../components/add-token-button";
 import { Callout } from "../../components/callout";
@@ -25,9 +26,9 @@ export const CodeUsed = ({ address }: { address: string | null }) => {
           }
         />
       </p>
-      <div style={{ display: "flex ", margin: "12px 0px" }}>
-        <hr style={{ flex: 1, marginRight: 12, marginTop: 12 }} />
-        Or <hr style={{ flex: 1, marginLeft: 12, marginTop: 12 }} />
+      <div className="or">
+        <hr />
+        {t("Or")} <hr />
       </div>
       <p>
         {t(

--- a/src/routes/home/token-details/token-details.tsx
+++ b/src/routes/home/token-details/token-details.tsx
@@ -21,14 +21,12 @@ const AddTokenTableCell = ({
   decimals,
   image,
   text,
-  buttonImage,
 }: {
   chainId: EthereumChainId;
   address: string;
   symbol: string;
   decimals: number;
   image: string;
-  buttonImage: string;
   text: string;
 }) => {
   return (
@@ -48,7 +46,6 @@ const AddTokenTableCell = ({
         symbol={symbol}
         decimals={decimals}
         image={image}
-        buttonImage={buttonImage}
       />
     </div>
   );
@@ -76,7 +73,6 @@ export const TokenDetails = ({
             symbol="$VEGA"
             image="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
             text={truncateMiddle(ADDRESSES.vegaTokenAddress)}
-            buttonImage="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
           />
         </td>
       </KeyValueTableRow>
@@ -90,7 +86,6 @@ export const TokenDetails = ({
             symbol="VEGA-Locked"
             image="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
             text={truncateMiddle(ADDRESSES.vestingAddress)}
-            buttonImage="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
           />
         </td>
       </KeyValueTableRow>

--- a/src/routes/home/token-details/token-details.tsx
+++ b/src/routes/home/token-details/token-details.tsx
@@ -8,11 +8,55 @@ import { useTranslation } from "react-i18next";
 import { useAppState } from "../../../contexts/app-state/app-state-context";
 import { TokenDetailsCirculating } from "./token-details-circulating";
 import { truncateMiddle } from "../../../lib/truncate-middle";
-import { ADDRESSES } from "../../../config";
+import { ADDRESSES, EthereumChainId } from "../../../config";
 import { formatNumber } from "../../../lib/format-number";
 import { BigNumber } from "../../../lib/bignumber";
 import { EtherscanLink } from "../../../components/etherscan-link";
 import { useAddAssetToWallet } from "../../../hooks/use-add-asset-to-wallet";
+
+const AddTokenTableCell = ({
+  chainId,
+  address,
+  symbol,
+  decimals,
+  image,
+  text,
+}: {
+  chainId: EthereumChainId;
+  address: string;
+  symbol: string;
+  decimals: number;
+  image: string;
+  text: string;
+}) => {
+  const addToken = useAddAssetToWallet(address, symbol, decimals, image);
+  return (
+    <div style={{ display: "flex", justifyContent: "flex-end" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          marginRight: 6,
+        }}
+      >
+        <EtherscanLink chainId={chainId} address={address} text={text} />
+      </div>
+      <button className="button-link" onClick={addToken}>
+        <img
+          style={{
+            width: 32,
+            height: 32,
+            border: "1px solid white",
+            borderRadius: 2,
+          }}
+          alt="token-logo"
+          src="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
+        />
+      </button>
+    </div>
+  );
+};
 
 export const TokenDetails = ({
   totalSupply,
@@ -23,43 +67,31 @@ export const TokenDetails = ({
 }) => {
   const { t } = useTranslation();
   const { appState } = useAppState();
-  const addToken = useAddAssetToWallet(
-    ADDRESSES.vegaTokenAddress,
-    "$VEGA",
-    18,
-    "https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
-  );
 
   return (
     <KeyValueTable className={"token-details"}>
       <KeyValueTableRow>
         <th>{t("Token address")}</th>
         <td data-testid="token-address">
-          <EtherscanLink
+          <AddTokenTableCell
             chainId={appState.chainId}
+            decimals={18}
             address={ADDRESSES.vegaTokenAddress}
+            symbol="$VEGA"
+            image="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
             text={truncateMiddle(ADDRESSES.vegaTokenAddress)}
           />
-          <button className="button-link" onClick={addToken}>
-            <img
-              style={{
-                width: 32,
-                height: 32,
-                border: "1px solid white",
-                borderRadius: 2,
-              }}
-              alt="token-logo"
-              src="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
-            />
-          </button>
         </td>
       </KeyValueTableRow>
       <KeyValueTableRow>
         <th>{t("Vesting contract")}</th>
         <td data-testid="token-contract">
-          <EtherscanLink
+          <AddTokenTableCell
             chainId={appState.chainId}
-            address={ADDRESSES.vestingAddress}
+            decimals={18}
+            address={ADDRESSES.lockedAddress}
+            symbol="VEGA-Locked"
+            image="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
             text={truncateMiddle(ADDRESSES.vestingAddress)}
           />
         </td>

--- a/src/routes/home/token-details/token-details.tsx
+++ b/src/routes/home/token-details/token-details.tsx
@@ -40,9 +40,17 @@ export const TokenDetails = ({
             address={ADDRESSES.vegaTokenAddress}
             text={truncateMiddle(ADDRESSES.vegaTokenAddress)}
           />
-          &nbsp;
           <button className="button-link" onClick={addToken}>
-            + Add to wallet
+            <img
+              style={{
+                width: 32,
+                height: 32,
+                border: "1px solid white",
+                borderRadius: 2,
+              }}
+              alt="token-logo"
+              src="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
+            />
           </button>
         </td>
       </KeyValueTableRow>

--- a/src/routes/home/token-details/token-details.tsx
+++ b/src/routes/home/token-details/token-details.tsx
@@ -12,7 +12,7 @@ import { ADDRESSES, EthereumChainId } from "../../../config";
 import { formatNumber } from "../../../lib/format-number";
 import { BigNumber } from "../../../lib/bignumber";
 import { EtherscanLink } from "../../../components/etherscan-link";
-import { useAddAssetToWallet } from "../../../hooks/use-add-asset-to-wallet";
+import { AddTokenButton } from "../../../components/add-token-button";
 
 const AddTokenTableCell = ({
   chainId,
@@ -21,15 +21,16 @@ const AddTokenTableCell = ({
   decimals,
   image,
   text,
+  buttonImage,
 }: {
   chainId: EthereumChainId;
   address: string;
   symbol: string;
   decimals: number;
   image: string;
+  buttonImage: string;
   text: string;
 }) => {
-  const addToken = useAddAssetToWallet(address, symbol, decimals, image);
   return (
     <div style={{ display: "flex", justifyContent: "flex-end" }}>
       <div
@@ -42,18 +43,13 @@ const AddTokenTableCell = ({
       >
         <EtherscanLink chainId={chainId} address={address} text={text} />
       </div>
-      <button className="button-link" onClick={addToken}>
-        <img
-          style={{
-            width: 32,
-            height: 32,
-            border: "1px solid white",
-            borderRadius: 2,
-          }}
-          alt="token-logo"
-          src="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
-        />
-      </button>
+      <AddTokenButton
+        address={address}
+        symbol={symbol}
+        decimals={decimals}
+        image={image}
+        buttonImage={buttonImage}
+      />
     </div>
   );
 };
@@ -80,6 +76,7 @@ export const TokenDetails = ({
             symbol="$VEGA"
             image="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
             text={truncateMiddle(ADDRESSES.vegaTokenAddress)}
+            buttonImage="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
           />
         </td>
       </KeyValueTableRow>
@@ -93,6 +90,7 @@ export const TokenDetails = ({
             symbol="VEGA-Locked"
             image="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
             text={truncateMiddle(ADDRESSES.vestingAddress)}
+            buttonImage="https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
           />
         </td>
       </KeyValueTableRow>

--- a/src/routes/home/token-details/token-details.tsx
+++ b/src/routes/home/token-details/token-details.tsx
@@ -12,40 +12,7 @@ import { ADDRESSES } from "../../../config";
 import { formatNumber } from "../../../lib/format-number";
 import { BigNumber } from "../../../lib/bignumber";
 import { EtherscanLink } from "../../../components/etherscan-link";
-import React from "react";
-
-const useAddToWallet = (
-  address: string,
-  symbol: string,
-  decimals: number,
-  image: string
-) => {
-  const { provider } = useAppState();
-  return React.useCallback(async () => {
-    try {
-      const wasAdded = await provider.request({
-        method: "wallet_watchAsset",
-        params: {
-          type: "ERC20",
-          options: {
-            address,
-            symbol,
-            decimals,
-            image,
-          },
-        },
-      });
-
-      if (wasAdded) {
-        console.log("Thanks for your interest!");
-      } else {
-        console.log("Your loss!");
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  }, [address, decimals, image, provider, symbol]);
-};
+import { useAddAssetToWallet } from "../../../hooks/use-add-asset-to-wallet";
 
 export const TokenDetails = ({
   totalSupply,
@@ -56,7 +23,7 @@ export const TokenDetails = ({
 }) => {
   const { t } = useTranslation();
   const { appState } = useAppState();
-  const addToken = useAddToWallet(
+  const addToken = useAddAssetToWallet(
     ADDRESSES.vegaTokenAddress,
     "$VEGA",
     18,

--- a/src/routes/home/token-details/token-details.tsx
+++ b/src/routes/home/token-details/token-details.tsx
@@ -12,6 +12,40 @@ import { ADDRESSES } from "../../../config";
 import { formatNumber } from "../../../lib/format-number";
 import { BigNumber } from "../../../lib/bignumber";
 import { EtherscanLink } from "../../../components/etherscan-link";
+import React from "react";
+
+const useAddToWallet = (
+  address: string,
+  symbol: string,
+  decimals: number,
+  image: string
+) => {
+  const { provider } = useAppState();
+  return React.useCallback(async () => {
+    try {
+      const wasAdded = await provider.request({
+        method: "wallet_watchAsset",
+        params: {
+          type: "ERC20",
+          options: {
+            address,
+            symbol,
+            decimals,
+            image,
+          },
+        },
+      });
+
+      if (wasAdded) {
+        console.log("Thanks for your interest!");
+      } else {
+        console.log("Your loss!");
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }, [address, decimals, image, provider, symbol]);
+};
 
 export const TokenDetails = ({
   totalSupply,
@@ -21,8 +55,13 @@ export const TokenDetails = ({
   totalStaked: BigNumber;
 }) => {
   const { t } = useTranslation();
-
   const { appState } = useAppState();
+  const addToken = useAddToWallet(
+    ADDRESSES.vegaTokenAddress,
+    "$VEGA",
+    18,
+    "https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
+  );
 
   return (
     <KeyValueTable className={"token-details"}>
@@ -34,6 +73,10 @@ export const TokenDetails = ({
             address={ADDRESSES.vegaTokenAddress}
             text={truncateMiddle(ADDRESSES.vegaTokenAddress)}
           />
+          &nbsp;
+          <button className="button-link" onClick={addToken}>
+            + Add to wallet
+          </button>
         </td>
       </KeyValueTableRow>
       <KeyValueTableRow>

--- a/src/routes/liquidity/dex-table.tsx
+++ b/src/routes/liquidity/dex-table.tsx
@@ -7,6 +7,7 @@ import { Link } from "react-router-dom";
 import { Routes } from "../router-config";
 import { LiquidityState, LiquidityAction } from "./liquidity-reducer";
 import { REWARDS_POOL_ADDRESSES } from "../../config";
+import { AddTokenButton } from "../../components/add-token-button";
 
 const BASE_SUSHI_URL = "https://analytics.sushi.com/pairs/";
 interface DexTokensSectionProps {
@@ -43,7 +44,28 @@ export const DexTokensSection = ({
 
   return (
     <section className="dex-tokens-section">
-      <h3>{name}</h3>
+      <h3>
+        <div style={{ display: "flex", justifyContent: "flex-start" }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              marginRight: 6,
+            }}
+          >
+            {name}{" "}
+          </div>
+          <AddTokenButton
+            address={values.lpTokenAddress}
+            symbol="SLP"
+            decimals={18}
+            image={
+              "https://s2.coinmarketcap.com/static/img/coins/64x64/10223.png"
+            }
+          />
+        </div>
+      </h3>
       <table className="dex-tokens-section__table">
         <tbody>
           <tr>

--- a/src/routes/liquidity/hooks.ts
+++ b/src/routes/liquidity/hooks.ts
@@ -24,11 +24,13 @@ export const useGetLiquidityBalances = (
           rewardPoolBalance,
           estimateAPY,
           awardContractAddress,
-        ] = await Promise.all<BigNumber, BigNumber, BigNumber, string>([
+          lpTokenAddress,
+        ] = await Promise.all<BigNumber, BigNumber, BigNumber, string, string>([
           await lpStaking.rewardPerEpoch(),
           await lpStaking.totalStaked(),
           await lpStaking.estimateAPY(),
           await lpStaking.awardContractAddress(),
+          await lpStaking.lpTokenAddress(),
         ]);
         let availableLPTokens = null;
         let stakedLPTokens = null;
@@ -57,6 +59,7 @@ export const useGetLiquidityBalances = (
             rewardPoolBalance,
             estimateAPY,
             awardContractAddress,
+            lpTokenAddress,
             availableLPTokens,
             stakedLPTokens: stakedLPTokens?.earningRewards,
             pendingStakedLPTokens: stakedLPTokens?.pending,

--- a/src/routes/liquidity/liquidity-reducer.ts
+++ b/src/routes/liquidity/liquidity-reducer.ts
@@ -5,6 +5,7 @@ export interface LpContractData {
   rewardPerEpoch: BigNumber;
   rewardPoolBalance: BigNumber;
   awardContractAddress: string;
+  lpTokenAddress: string;
   estimateAPY: BigNumber;
   availableLPTokens: BigNumber | null;
   stakedLPTokens: BigNumber | null;


### PR DESCRIPTION
Closes #359 

(apologies branch is out of date as I have been doing this in my own time for funsies and haven't updated)

I think before merging we need some better icon/logo-ography. I have used the Vega logo for all of these tokens however that would be confusing in a wallet, I think we need a separate logos for:

* Vega (we have this)
* Locked vega
* SLP ETH/VEGA
* SLP USDC/VEGA

These should all be 32px and we should bare in mind when in wallet and in MM has rounded icons as well.

@campbellssource what's the process for this? Is this something we can do or is this a big fan request.

![Screenshot 2021-09-19 at 13 52 23](https://user-images.githubusercontent.com/26136207/133928228-41895a15-81c0-4760-8957-35e1343305e8.png)

![Screenshot 2021-09-19 at 13 52 34](https://user-images.githubusercontent.com/26136207/133928230-edf4185c-3ca8-4379-8cb2-58ef61526fde.png)

![Screenshot 2021-09-19 at 13 52 42](https://user-images.githubusercontent.com/26136207/133928234-d7a944b4-5df6-47a2-a306-c7b00d8a1f37.png)

