### PR TITLE
Prevent wrapping of wallet amounts

### DIFF
--- a/src/components/wallet-card/wallet-card.scss
+++ b/src/components/wallet-card/wallet-card.scss
@@ -35,8 +35,14 @@
     text-transform: uppercase;
     padding: 2px;
 
+    span:first-child {
+      max-width: 140px;
+    }
+
     span:last-child {
       font-family: $font-mono;
+      flex: 1 1 0;
+      text-align: right;
     }
 
     &--dark {


### PR DESCRIPTION
CSS fix for wallet amounts alignment

Before:
<img width="416" alt="Screenshot 2021-09-29 at 11 14 50" src="https://user-images.githubusercontent.com/6803987/135249904-7ae610be-ee16-4cf1-9581-4d30582b6232.png">

After:
<img width="424" alt="Screenshot 2021-09-29 at 11 14 29" src="https://user-images.githubusercontent.com/6803987/135249929-8baf0f36-5a06-404b-bbae-0c51a9f7037a.png">

