### PR TITLE
Hide APY row from dex liquidity table

### DIFF
--- a/src/routes/liquidity/dex-table/dex-table.tsx
+++ b/src/routes/liquidity/dex-table/dex-table.tsx
@@ -107,10 +107,11 @@ export const DexTokensSection = ({
             />
           </td>
         </KeyValueTableRow>
-        <KeyValueTableRow>
+        {/* TODO: Re-add this row when APY calculation is correct */}
+        {/* <KeyValueTableRow>
           <th>{t("lpTokensEstimateAPY")}</th>
           <td>{values.estimateAPY.decimalPlaces(2).toString()}%</td>
-        </KeyValueTableRow>
+        </KeyValueTableRow> */}
         <KeyValueTableRow>
           <th>{t("lpTokensInRewardPool")}</th>
           <td>


### PR DESCRIPTION
As per title. 

The calculation is currently incorrect so we need to hide it until fixed