### PR TITLE
Update tranche labels for new tranches

### DIFF
--- a/src/routes/tranches/tranche-label.tsx
+++ b/src/routes/tranches/tranche-label.tsx
@@ -5,7 +5,8 @@ const TRANCHE_LABELS: Record<number, string[]> = {
   "5": ["Coinlist Option 1", "Community Whitelist"],
   "6": ["Coinlist Option 2"],
   "7": ["Coinlist Option 3"],
-  "10": ["Liquidity Prerelease"],
+  "15": ["Coinlist Option 1", "Community Whitelist", "Coinlist wallets"],
+  "16": ["Coinlist Option 2", "Coinlist wallets"],  
 };
 
 /**


### PR DESCRIPTION
Some minor changes to the tranche labels:
- Add tranche 15 & 16, which were just created
- Remove label for tranche 10

Tranche 10’s label was true, but also contained other tokens that were issued unlocked, so it was deemed to be clearer to have it unlabelled than a semi-correct label, or another potentially misleading label. Checked this with @barnabee & @davidsiska-vega as they were in the room.