### PR TITLE
Update association pending text once confirmations threshold is passed

### DIFF
--- a/src/i18n/translations/dev.json
+++ b/src/i18n/translations/dev.json
@@ -250,6 +250,7 @@
   "Wallet": "Wallet",
   "Nominate Stake to Validator Node": "Nominate Stake to Validator Node",
   "Associating Tokens": "Associating with Vega key",
+  "associationPendingWaitingForVega": "Waiting for Vega to credit key...",
   "Done": "Done",
   "Associating {{amount}} VEGA tokens with Vega key {{vegaKey}}": "Associating {{amount}} VEGA tokens with Vega key {{vegaKey}}",
   "pendingAssociationText": "The Vega network requires {{confirmations}} Confirmations (approx 5 minutes) on Ethereum before crediting your Vega key with your tokens. This page will update once complete or you can come back and check your Vega wallet to see if it is ready to use.",

--- a/src/routes/staking/associate/associate-page.tsx
+++ b/src/routes/staking/associate/associate-page.tsx
@@ -49,7 +49,7 @@ export const AssociatePage = ({
   const linking = usePollForStakeLinking(vegaKey.pub, txState.txData.hash);
 
   const {
-    appState: { walletBalance, totalVestedBalance, totalLockedBalance },
+    appState: { chainId, walletBalance, totalVestedBalance, totalLockedBalance },
   } = useAppState();
 
   const zeroVesting = totalVestedBalance.plus(totalLockedBalance).isEqualTo(0);
@@ -63,6 +63,7 @@ export const AssociatePage = ({
         dispatch={txDispatch}
         requiredConfirmations={requiredConfirmations}
         linking={linking}
+        chainId={chainId}
       />
     );
   }


### PR DESCRIPTION
Updates the pending text to "Waiting for Vega to credit key..." once the confirmation countdown is complete.

I don't love this code I wonder if we need to refactor the TransactionCallout component to make it a bit more reusable.