### PR TITLE
Fix double permissions request on initial connection to metamask

### DIFF
--- a/src/hooks/use-eth-user.ts
+++ b/src/hooks/use-eth-user.ts
@@ -18,9 +18,11 @@ export function useEthUser() {
   const { token, staking, vesting } = useContracts();
   const connectTimer = React.useRef<any>();
   const getUserTrancheBalances = useGetUserTrancheBalances(appState.ethAddress);
-  const [hasConnected, setHasConnected] = useLocalStorage(
+  const [hasConnected, setHasConnected] = useLocalStorage<boolean | null>(
     CONNECTED_STORAGE_KEY,
-    false
+    // null indicates not set (initial app start), false indicates
+    // user disconnected, and true indicates user connected
+    null
   );
 
   const connect = React.useCallback(async () => {
@@ -42,7 +44,7 @@ export function useEthUser() {
         method: "eth_requestAccounts",
       });
 
-      if (!hasConnected) {
+      if (hasConnected !== null && !hasConnected) {
         await provider.request({
           method: "wallet_requestPermissions",
           params: [{ eth_accounts: {} }],

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,17 +1,22 @@
 import React from "react";
 import { LocalStorage } from "../lib/storage";
 
-export function useLocalStorage(key: string, initialValue: any) {
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, React.Dispatch<React.SetStateAction<T>>] {
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
-  const [storedValue, setStoredValue] = React.useState(() => {
+  const [storedValue, setStoredValue] = React.useState<T>(() => {
     const item = LocalStorage.getItem(key);
-    return item ? item : null;
+
+    // If item is null nothing was found in localStorage so use the initial value
+    return item !== null ? item : initialValue;
   });
 
   // Return a wrapped version of useState's setter function that
   // persists the new value to localStorage.
-  const setValue = (value: any | ((currValue: any) => void)) => {
+  const setValue = (value: T | ((currValue: T) => T)) => {
     const valueToStore = value instanceof Function ? value(storedValue) : value;
     setStoredValue(valueToStore);
     LocalStorage.setItem(key, value);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,4 @@
-// TODO fine for now however will leak state between tests (we don't really have) in future. Ideally should use a provider
+// TODO: fine for now however will leak state between tests (we don't really have) in future. Ideally should use a provider
 export const LocalStorage = {
   getItem: (key: string) => {
     try {


### PR DESCRIPTION
Fixes a bug where you would have to confirm permissions twice upon initial connection. This was because I wasn't properly handling the initial value passed to the useLocalStorage hook, which meant that we were calling both `request_ethAccounts` and `wallet_reqeustPermissions`

- Uses initialValue correctly in the local storage hook
- Sets initial storage value to null so we can detect initial app connection.
- Adds stricter types for useLocalStorage hook