### PR TITLE
Chore/620 format numbers

### DIFF
--- a/src/routes/liquidity/dex-table/dex-table.tsx
+++ b/src/routes/liquidity/dex-table/dex-table.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../../components/key-value-table";
 import { EpochCountdown } from "../../../components/epoch-countdown";
 import { useWeb3 } from "../../../contexts/web3-context/web3-context";
+import { formatNumber } from "../../../lib/format-number";
 
 interface DexTokensSectionProps {
   name: string;
@@ -72,7 +73,7 @@ export const DexTokensSection = ({
         <KeyValueTableRow>
           <th>{t("rewardPerEpoch")}</th>
           <td>
-            {values.rewardPerEpoch.toString()} {t("VEGA")}
+            {formatNumber(values.rewardPerEpoch)} {t("VEGA")}
           </td>
         </KeyValueTableRow>
         <KeyValueTableRow>
@@ -103,7 +104,7 @@ export const DexTokensSection = ({
         <KeyValueTableRow>
           <th>{t("lpTokensInRewardPool")}</th>
           <td>
-            {values.rewardPoolBalance.toString()} {t("SLP")}
+            {formatNumber(values.rewardPoolBalance)} {t("SLP")}
           </td>
         </KeyValueTableRow>
         {ethAddress ? (
@@ -163,7 +164,7 @@ const ConnectedRows = ({
         <th>{t("usersLpTokens")}</th>
         <td>
           <div>
-            {availableLPTokens.toString()}&nbsp;{t("SLP")}
+            {formatNumber(availableLPTokens)}&nbsp;{t("SLP")}
           </div>
           {hasDeposited ? (
             <span className="text-muted">{t("alreadyDeposited")}</span>
@@ -186,20 +187,20 @@ const ConnectedRows = ({
         </th>
         <td>
           {pendingStakedLPTokens?.isGreaterThan(0)
-            ? pendingStakedLPTokens?.toString()
-            : stakedLPTokens?.toString()}
+            ? formatNumber(pendingStakedLPTokens)
+            : formatNumber(stakedLPTokens)}
           &nbsp;{t("SLP")}
         </td>
       </KeyValueTableRow>
       <KeyValueTableRow>
         <th>{t("usersShareOfPool")}</th>
-        <td>{shareOfPool.toString()}%</td>
+        <td>{formatNumber(shareOfPool)}%</td>
       </KeyValueTableRow>
       <KeyValueTableRow>
         <th>{t("usersAccumulatedRewards")}</th>
         <td>
           <div>
-            {accumulatedRewards.toString()} {t("VEGA")}
+            {formatNumber(accumulatedRewards)} {t("VEGA")}
           </div>
           {(hasDeposited || hasRewards) && (
             <div style={{ marginTop: 3 }}>

--- a/src/routes/liquidity/withdraw/index.tsx
+++ b/src/routes/liquidity/withdraw/index.tsx
@@ -24,6 +24,7 @@ import { Error } from "../../../components/icons";
 import { Link } from "react-router-dom";
 import { Routes } from "../../router-config";
 import { useWeb3 } from "../../../contexts/web3-context/web3-context";
+import { formatNumber } from "../../../lib/format-number";
 
 export const LiquidityWithdrawPage = ({
   lpTokenAddress,
@@ -141,14 +142,19 @@ export const LiquidityWithdrawPage = ({
             <KeyValueTableRow>
               <th>{t("liquidityTokenWithdrawBalance")}</th>
               <td>
-                {values.connectedWalletData?.totalStaked.toString() || 0}&nbsp;
+                {values.connectedWalletData?.totalStaked
+                  ? formatNumber(values.connectedWalletData.totalStaked)
+                  : 0}
+                &nbsp;
                 {t("SLP")}
               </td>
             </KeyValueTableRow>
             <KeyValueTableRow>
               <th>{t("liquidityTokenWithdrawRewards")}</th>
               <td>
-                {values.connectedWalletData?.accumulatedRewards.toString() || 0}
+                {values.connectedWalletData?.accumulatedRewards
+                  ? formatNumber(values.connectedWalletData.accumulatedRewards)
+                  : 0}
                 &nbsp;
                 {t("VEGA")}
               </td>

--- a/src/routes/redemption/home/vesting-table.tsx
+++ b/src/routes/redemption/home/vesting-table.tsx
@@ -6,6 +6,7 @@ import {
 import { BigNumber } from "../../../lib/bignumber";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { formatNumber } from "../../../lib/format-number";
 
 export interface VestingTableProps {
   vested: BigNumber;
@@ -40,28 +41,28 @@ export const VestingTable = ({
           className="vesting-table__top-solid-border"
         >
           <th>{t("Vesting VEGA")}</th>
-          <td>{total.toString()}</td>
+          <td>{formatNumber(total)}</td>
         </KeyValueTableRow>
         <KeyValueTableRow data-testid="vesting-table-locked">
           <th>
             <div className="vesting-table__indicator-square vesting-table__indicator-square--locked"></div>
             {t("Locked")}
           </th>
-          <td>{locked.toString()}</td>
+          <td>{formatNumber(locked)}</td>
         </KeyValueTableRow>
         <KeyValueTableRow data-testid="vesting-table-unlocked">
           <th>
             <div className="vesting-table__indicator-square vesting-table__indicator-square--unlocked"></div>
             {t("Unlocked")}
           </th>
-          <td>{vested.toString()}</td>
+          <td>{formatNumber(vested)}</td>
         </KeyValueTableRow>
         <KeyValueTableRow data-testid="vesting-table-staked">
           <th>
             <div className="vesting-table__indicator-square vesting-table__indicator-square--staked"></div>
             {t("Associated")}
           </th>
-          <td>{associated.toString()}</td>
+          <td>{formatNumber(associated)}</td>
         </KeyValueTableRow>
       </KeyValueTable>
       <div className="vesting-table__progress-bar">

--- a/src/routes/redemption/tranche-table.tsx
+++ b/src/routes/redemption/tranche-table.tsx
@@ -10,6 +10,7 @@ import { BigNumber } from "../../lib/bignumber";
 import { Link } from "react-router-dom";
 import { TrancheItem } from "./tranche-item";
 import { Routes } from "../router-config";
+import { formatNumber } from "../../lib/format-number";
 
 export interface TrancheTableProps {
   tranche: {
@@ -43,11 +44,11 @@ export const Tranche0Table = ({
               {t("Tranche")} {trancheId}
             </span>
           </th>
-          <td>{total.toString()}</td>
+          <td>{formatNumber(total)}</td>
         </KeyValueTableRow>
         <KeyValueTableRow data-testid="tranche-table-locked">
           <th>{t("Locked")}</th>
-          <td>{total.toString()}</td>
+          <td>{formatNumber(total)}</td>
         </KeyValueTableRow>
       </KeyValueTable>
       <div className="tranche-table__footer" data-testid="tranche-table-footer">

--- a/src/routes/redemption/tranche/index.tsx
+++ b/src/routes/redemption/tranche/index.tsx
@@ -17,6 +17,7 @@ import { Routes } from "../../router-config";
 import { RedemptionState } from "../redemption-reducer";
 import { TrancheTable } from "../tranche-table";
 import { useContracts } from "../../../contexts/contracts/contracts-context";
+import { formatNumber } from "../../../lib/format-number";
 
 export const RedeemFromTranche = ({
   state,
@@ -50,7 +51,7 @@ export const RedeemFromTranche = ({
   const redeemedAmount = React.useMemo(() => {
     return (
       trancheBalances.find(({ id: bId }) => bId.toString() === id.toString())
-        ?.vested || new BigNumber(0).toString()
+        ?.vested || new BigNumber(0)
     );
     // Do not update this value as it is updated once the tranches are refetched on success and we want the old value
     // so do not react to anything
@@ -101,7 +102,7 @@ export const RedeemFromTranche = ({
                 {t(
                   "You have redeemed {{redeemedAmount}} VEGA tokens from this tranche. They are now free to transfer from your Ethereum wallet.",
                   {
-                    redeemedAmount: redeemedAmount.toString(),
+                    redeemedAmount: formatNumber(redeemedAmount),
                   }
                 )}
               </p>

--- a/src/routes/staking/staking.tsx
+++ b/src/routes/staking/staking.tsx
@@ -13,6 +13,7 @@ import React from "react";
 import { Staking as StakingQueryResult } from "./__generated__/Staking";
 import { useVegaUser } from "../../hooks/use-vega-user";
 import { useWeb3 } from "../../contexts/web3-context/web3-context";
+import { formatNumber } from "../../lib/format-number";
 
 export const Staking = ({ data }: { data?: StakingQueryResult }) => {
   const { t } = useTranslation();
@@ -138,7 +139,7 @@ export const StakingStepAssociate = ({
       <Callout
         intent="success"
         icon={<Tick />}
-        title={t("stakingHasAssociated", { tokens: associated.toString() })}
+        title={t("stakingHasAssociated", { tokens: formatNumber(associated) })}
       >
         <p>
           <Link to="/staking/associate">

--- a/src/routes/staking/validator-table.tsx
+++ b/src/routes/staking/validator-table.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../components/key-value-table";
 import { BigNumber } from "../../lib/bignumber";
 import { Staking_nodes } from "./__generated__/Staking";
+import { formatNumber } from "../../lib/format-number";
 
 export interface ValidatorTableProps {
   node: Staking_nodes;
@@ -69,7 +70,7 @@ export const ValidatorTable = ({
         </KeyValueTableRow>
         <KeyValueTableRow>
           <th>{t("OWN STAKE (THIS EPOCH)")}</th>
-          <td>{stakeThisEpoch.toString()}</td>
+          <td>{formatNumber(stakeThisEpoch)}</td>
         </KeyValueTableRow>
         <KeyValueTableRow>
           <th>{t("NOMINATED (THIS EPOCH)")}</th>

--- a/src/routes/staking/your-stake.tsx
+++ b/src/routes/staking/your-stake.tsx
@@ -5,6 +5,7 @@ import {
   KeyValueTableRow,
 } from "../../components/key-value-table";
 import { BigNumber } from "../../lib/bignumber";
+import { formatNumber } from "../../lib/format-number";
 
 export interface YourStakeProps {
   stakeThisEpoch: BigNumber;
@@ -23,11 +24,11 @@ export const YourStake = ({
       <KeyValueTable>
         <KeyValueTableRow>
           <th>{t("Your Stake On Node (This Epoch)")}</th>
-          <td data-testid="stake-this-epoch">{stakeThisEpoch.toString()}</td>
+          <td data-testid="stake-this-epoch">{formatNumber(stakeThisEpoch)}</td>
         </KeyValueTableRow>
         <KeyValueTableRow>
           <th>{t("Your Stake On Node (Next Epoch)")}</th>
-          <td data-testid="stake-next-epoch">{stakeNextEpoch.toString()}</td>
+          <td data-testid="stake-next-epoch">{formatNumber(stakeNextEpoch)}</td>
         </KeyValueTableRow>
       </KeyValueTable>
     </div>

--- a/src/routes/tranches/tranche.tsx
+++ b/src/routes/tranches/tranche.tsx
@@ -51,7 +51,7 @@ export const Tranche = ({ tranches }: { tranches: TrancheType[] }) => {
       />
       <div className="tranche__redeemed">
         <span>{t("alreadyRedeemed")}</span>
-        <span>{tranche.total_removed.toString()}</span>
+        <span>{formatNumber(tranche.total_removed)}</span>
       </div>
       <h2>{t("Holders")}</h2>
       {tranche.users.length ? (


### PR DESCRIPTION
- Replaces usage of `someBigNum.toString()` with `formatNumber(someBigNum)`
- Where applicable change some logic to return BigNumbers rather than strings to make formatting easier later on

Closes #620 