### PR TITLE
Opera doesnt return a chain ID so... cross fingers?

### DIFF
--- a/src/contexts/web3-context/web3-provider.tsx
+++ b/src/contexts/web3-context/web3-provider.tsx
@@ -104,7 +104,7 @@ export const Web3Provider = ({ children }: { children: JSX.Element }) => {
       } else {
         try {
           const chainId = await web3.eth.getChainId();
-          setChainId(APP_CHAIN_ID as EthereumChainId);
+          setChainId(`0x${chainId}` as EthereumChainId);
         } catch (e) {
           /* Fall back for Opera - just use the configured chain*/
           setChainId(APP_CHAIN_ID as EthereumChainId);


### PR DESCRIPTION
Sets a chain ID when web3 won't give us one

- Add a `catch` for chainID not returning

Maybe closes #637
