### PR TITLE
Fix Associate/Disassociate getting truncated in breadcrumb

### DIFF
--- a/src/components/nav/breadcrumbs.tsx
+++ b/src/components/nav/breadcrumbs.tsx
@@ -6,30 +6,53 @@ import { truncateMiddle } from "../../lib/truncate-middle";
 import React from "react";
 
 export const Breadcrumbs = () => {
-  const breadcrumbs = useBreadcrumbs();
+  const breadcrumbs = useBreadcrumbs([
+    // need to explicitly specify truncate: false for staking routes otherwise they
+    // they will match /staking/:nodeid
+    {
+      path: "/staking/associate",
+      props: { truncate: false },
+    },
+    {
+      path: "/staking/disassociate",
+      props: { truncate: false },
+    },
+    {
+      path: "/staking/:node",
+      props: { truncate: true },
+    },
+  ]);
   const isClaim = useRouteMatch("/claim");
   return !isClaim && breadcrumbs.length > 1 ? (
     <div className="breadcrumbs">
-      {breadcrumbs.map(({ breadcrumb, match }, index) => (
-        <div key={`${index}-container`} data-testid="breadcrumb">
-          <Link to={match.url} key={`${index}-link`}>
-            {isStakeNodePage(match.url)
-              ? React.cloneElement(breadcrumb as React.ReactElement, {
-                  children: truncateMiddle(
-                    (breadcrumb as React.ReactElement).props.children
-                  ),
-                })
-              : breadcrumb}
-          </Link>
-          <span key={`${index}-spacer`} className="breadcrumbs__spacer">
-            {index !== breadcrumbs.length - 1 && ">"}
-          </span>
-        </div>
-      ))}
+      {breadcrumbs.map(
+        (
+          {
+            breadcrumb,
+            match,
+            // @ts-ignore // seemingly no way of typing additional breadcrumb props
+            truncate,
+          },
+          index
+        ) => {
+          return (
+            <div key={`${index}-container`} data-testid="breadcrumb">
+              <Link to={match.url} key={`${index}-link`}>
+                {truncate
+                  ? React.cloneElement(breadcrumb as React.ReactElement, {
+                      children: truncateMiddle(
+                        (breadcrumb as React.ReactElement).props.children
+                      ),
+                    })
+                  : breadcrumb}
+              </Link>
+              <span key={`${index}-spacer`} className="breadcrumbs__spacer">
+                {index !== breadcrumbs.length - 1 && ">"}
+              </span>
+            </div>
+          );
+        }
+      )}
     </div>
   ) : null;
 };
-
-function isStakeNodePage(url: string) {
-  return /\/staking\/[a-zA-Z0-9]+$/.test(url);
-}


### PR DESCRIPTION
- Adds a truncate prop to the breadcrumb config, uses the prop rather than regex on the url to ensure truncation

Closes #662 