### PR TITLE
Font weights for page titles

### DIFF
--- a/src/components/heading/heading.scss
+++ b/src/components/heading/heading.scss
@@ -1,6 +1,6 @@
 .heading {
   &__title {
-    font-weight: 500;
+    font-weight: normal;
     font-size: 40px;
     margin: 0;
     max-width: 80%;


### PR DESCRIPTION
The pixelated font does not have multiple weights, and page headings have a heavier weight meaning they look bad.
This sets the weight on page titles to normal.

Closes #678 

before:

<img width="452" alt="Screenshot 2021-10-21 at 16 41 00" src="https://user-images.githubusercontent.com/13255539/138312467-d0df7e5a-db05-4538-8c72-c149fa7c2552.png">

After:

<img width="463" alt="Screenshot 2021-10-21 at 16 47 49" src="https://user-images.githubusercontent.com/13255539/138312537-65b51885-a6d7-4edf-9a97-ef0b4fce5ab2.png">


