### PR TITLE
Task/696 Dont expose version number in url field for vega wallet

### DIFF
--- a/src/i18n/translations/dev.json
+++ b/src/i18n/translations/dev.json
@@ -155,6 +155,7 @@
   "Wallet service unavailable": "Wallet service not running at that url",
   "Session expired": "Session expired",
   "Invalid credentials": "Wallet or passphrase incorrect",
+  "Invalid wallet URL": "Invalid wallet URL",
   "noKeys": "No keys",
   "Stake VEGA tokens": "Stake VEGA tokens",
   "Tranche breakdown": "Tranche breakdown",

--- a/src/lib/vega-wallet/vega-wallet-service.ts
+++ b/src/lib/vega-wallet/vega-wallet-service.ts
@@ -21,6 +21,7 @@ export const Errors = {
   SESSION_EXPIRED: "Session expired",
   INVALID_CREDENTIALS: "Invalid credentials",
   COMMAND_FAILED: "Command failed",
+  INVALID_URL: "Invalid wallet URL",
 };
 
 export interface DelegateSubmissionInput {
@@ -82,7 +83,14 @@ export class VegaWalletService implements IVegaWalletService {
     passphrase: string;
     url: string;
   }): Promise<[string | undefined, string | undefined]> {
-    this.setWalletUrl(params.url);
+    const urlValid = this.validateUrl(params.url);
+
+    if (urlValid) {
+      this.setWalletUrl(params.url);
+    } else {
+      return [Errors.INVALID_URL, undefined];
+    }
+
     try {
       const res = await fetch(`${this.getUrl()}/${Endpoints.TOKEN}`, {
         method: "post",
@@ -209,6 +217,15 @@ export class VegaWalletService implements IVegaWalletService {
   private handleServiceUnavailable(returnVal?: any): [string, any] {
     this.clearWalletUrl();
     return [Errors.SERVICE_UNAVAILABLE, returnVal];
+  }
+
+  private validateUrl(url: string) {
+    try {
+      new URL(url);
+    } catch (err) {
+      return false;
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
Wallet version number is now handled internally. The user can only specify the base url of where the wallet is running

- Adds version property
- Construct the url per request
- Adds validation to check submitted url is at least a real url

Closes #696 