### PR TITLE
Task/694 Filter associations by vega key if zero

### DIFF
--- a/src/components/eth-wallet/eth-wallet.tsx
+++ b/src/components/eth-wallet/eth-wallet.tsx
@@ -72,6 +72,10 @@ const ConnectedKey = () => {
     return totalLockedBalance.plus(totalVestedBalance);
   }, [totalLockedBalance, totalVestedBalance]);
 
+  const associationsByVegaKey = Object.entries(
+    appState.associationBreakdown
+  ).filter(([, amount]) => amount.isGreaterThan(0));
+
   return (
     <>
       <WalletCardRow
@@ -117,20 +121,20 @@ const ConnectedKey = () => {
       )}
       {Flags.STAKING_DISABLED || Flags.REDEEM_DISABLED ? null : (
         <>
-          {Object.entries(appState.associationBreakdown).length ? (
+          {associationsByVegaKey.length ? (
             <>
               <hr style={{ borderStyle: "dashed", color: Colors.TEXT }} />
               <WalletCardRow label="Associated to" dark={true} />
-              {Object.entries(appState.associationBreakdown).map(
-                ([key, amount]) => (
+              {associationsByVegaKey.map(([key, amount]) => {
+                return (
                   <WalletCardRow
                     key={key}
                     label={truncateMiddle(key)}
                     value={amount}
                     valueSuffix={t("VEGA")}
                   />
-                )
-              )}
+                );
+              })}
             </>
           ) : null}
         </>


### PR DESCRIPTION
- Doesn't show the row for the vega key in the Ethereum wallet if the association amount is 0. This can be the case when the user has disassociated.
- Doesn't show the title 'Associated to' if there are no items to display

Closes #694 