### PR TITLE
Task/677 Dont show callout for approval if in staking flow

### DIFF
--- a/src/components/token-input/token-input.tsx
+++ b/src/components/token-input/token-input.tsx
@@ -148,7 +148,7 @@ export const TokenInput = ({
         </button>
       );
     }
-  } else {
+  } else if (requireApproval) {
     approveContent = (
       <Callout
         icon={<Tick />}


### PR DESCRIPTION
Adds an extra condition to only show approve success state if approvals are requried