### PR TITLE
Add spam protection warning on nominate form

### DIFF
--- a/src/i18n/translations/dev.json
+++ b/src/i18n/translations/dev.json
@@ -307,6 +307,7 @@
   "stakeFailed": "Failed to delegate to node {{node}}",
   "Remove {{amount}} VEGA tokens": "Remove {{amount}} VEGA tokens",
   "How much to {{action}} in next epoch?": "How much to {{action}} in next epoch?",
+  "Warning: spam protection exists": "Warning: You can only nominate a validator with VEGA tokens that have been associated in the previous epoch. This is spam protection feature. Also, your nomination must be greater than 1.0 VEGA. If you attempt to nominate in the same epoch or with less than 1.0 VEGA it will fail.",
   "lpTokensInvalidToken": "Address {{address}} is not a valid SLP token address for VEGA",
   "lpTxSuccessButton": "Review liquidity stake",
   "depositLpTokensHeading": "How much would you like to deposit?",

--- a/src/i18n/translations/dev.json
+++ b/src/i18n/translations/dev.json
@@ -307,7 +307,7 @@
   "stakeFailed": "Failed to delegate to node {{node}}",
   "Remove {{amount}} VEGA tokens": "Remove {{amount}} VEGA tokens",
   "How much to {{action}} in next epoch?": "How much to {{action}} in next epoch?",
-  "Warning, spam protection exists": "Warning: You can only nominate a validator with VEGA tokens that have been associated in the previous epoch. This is spam protection feature. Also, your nomination must be greater than 1.0 VEGA. If you attempt to nominate in the same epoch or with less than 1.0 VEGA it will fail.",
+  "Warning, spam protection exists": "Warning: You can only nominate a validator with VEGA tokens that have been associated in the previous epoch. This is spam protection feature. Also, your nomination must be greater than 0.1 VEGA. If you attempt to nominate in the same epoch or with less than 0.1 VEGA it will fail.",
   "lpTokensInvalidToken": "Address {{address}} is not a valid SLP token address for VEGA",
   "lpTxSuccessButton": "Review liquidity stake",
   "depositLpTokensHeading": "How much would you like to deposit?",

--- a/src/i18n/translations/dev.json
+++ b/src/i18n/translations/dev.json
@@ -307,7 +307,7 @@
   "stakeFailed": "Failed to delegate to node {{node}}",
   "Remove {{amount}} VEGA tokens": "Remove {{amount}} VEGA tokens",
   "How much to {{action}} in next epoch?": "How much to {{action}} in next epoch?",
-  "Warning: spam protection exists": "Warning: You can only nominate a validator with VEGA tokens that have been associated in the previous epoch. This is spam protection feature. Also, your nomination must be greater than 1.0 VEGA. If you attempt to nominate in the same epoch or with less than 1.0 VEGA it will fail.",
+  "Warning, spam protection exists": "Warning: You can only nominate a validator with VEGA tokens that have been associated in the previous epoch. This is spam protection feature. Also, your nomination must be greater than 1.0 VEGA. If you attempt to nominate in the same epoch or with less than 1.0 VEGA it will fail.",
   "lpTokensInvalidToken": "Address {{address}} is not a valid SLP token address for VEGA",
   "lpTxSuccessButton": "Review liquidity stake",
   "depositLpTokensHeading": "How much would you like to deposit?",

--- a/src/routes/staking/staking-form.tsx
+++ b/src/routes/staking/staking-form.tsx
@@ -204,7 +204,7 @@ export const StakingForm = ({
       {action !== undefined && (
         <>
           <h2>{t("How much to {{action}} in next epoch?", { action })}</h2>
-          <p><{t("Warning: spam protection exists")}</p>
+          <p>{t("Warning: spam protection exists")}</p>
           <TokenInput
             submitText={`${action} ${amount ? amount : ""} ${t("vegaTokens")}`}
             perform={onSubmit}

--- a/src/routes/staking/staking-form.tsx
+++ b/src/routes/staking/staking-form.tsx
@@ -204,7 +204,7 @@ export const StakingForm = ({
       {action !== undefined && (
         <>
           <h2>{t("How much to {{action}} in next epoch?", { action })}</h2>
-          <p>{t("Warning: spam protection exists")}</p>
+          <p>{t("Warning, spam protection exists")}</p>
           <TokenInput
             submitText={`${action} ${amount ? amount : ""} ${t("vegaTokens")}`}
             perform={onSubmit}

--- a/src/routes/staking/staking-form.tsx
+++ b/src/routes/staking/staking-form.tsx
@@ -204,6 +204,7 @@ export const StakingForm = ({
       {action !== undefined && (
         <>
           <h2>{t("How much to {{action}} in next epoch?", { action })}</h2>
+          <p><{t("Warning: spam protection exists")}</p>
           <TokenInput
             submitText={`${action} ${amount ? amount : ""} ${t("vegaTokens")}`}
             perform={onSubmit}


### PR DESCRIPTION
<img width="599" alt="Screenshot 2021-11-03 at 17 59 20" src="https://user-images.githubusercontent.com/13255539/140166288-05e195ea-ae20-4084-a431-0eab0ba45c5f.png"> 

closes #724 

This isn't a great solution so feel free to improve.

It adds a new line of copy to the add/remove form explaining the spam protection rules.

it isn't great because it show for both add and remove but is only relevant to the add.

