### PR TITLE
Fix/688 Fix undefined contract values error

### DIFF
--- a/src/i18n/translations/dev.json
+++ b/src/i18n/translations/dev.json
@@ -262,7 +262,7 @@
   "pendingAssociationText": "The Vega network requires a number of confirmations on Ethereum before crediting your Vega key with your tokens. You can see the number of confirmations that are required in the network parameters. This page will update once complete or you can come back and check your Vega wallet to see if it is ready to use.",
   "Vega key {{vegaKey}} can now participate in governance and Nominate a validator with it’s stake.": "Vega key {{vegaKey}} can now participate in governance and Nominate a validator with it’s stake.",
   "You have no VEGA tokens in your connected wallet. You will need to buy some VEGA tokens from an exchange in order to stake using this method.": "You have no VEGA tokens in your connected wallet. You will need to buy some VEGA tokens from an exchange in order to stake using this method.",
-  "All VEGA tokens in the connected wallet is already associated with a Vega wallet/key": "All VEGA tokens in the connected wallet is already associated with a Vega wallet/key",
+  "All VEGA tokens in the connected wallet is already associated with a Vega wallet/key": "All VEGA tokens in the connected wallet are already associated with a Vega wallet/key",
   "VEGA tokens are approved for staking": "VEGA tokens are approved for staking",
   "Approve VEGA tokens for staking on Vega": "Approve VEGA tokens for staking on Vega",
   "You have no VEGA tokens currently vesting.": "You have no VEGA tokens currently vesting.",

--- a/src/routes/staking/validator-table.tsx
+++ b/src/routes/staking/validator-table.tsx
@@ -46,7 +46,9 @@ export const ValidatorTable = ({
         </KeyValueTableRow>
         <KeyValueTableRow>
           <th>{t("ABOUT THIS VALIDATOR")}</th>
-          <td>{node.infoUrl}</td>
+          <td>
+            <a href={node.infoUrl}>{node.infoUrl}</a>
+          </td>
         </KeyValueTableRow>
         <KeyValueTableRow>
           <th>{t("IP ADDRESS")}</th>


### PR DESCRIPTION
Lifts contractData `values` state and renders a loading message until they are set. This way the hook in the child component doesn't render when they are undefined causing Sentry to capture the error.

Bonus.
- Fixes bad grammer in a translation
- Makes infoUrl a link as noticed by David. Ref: https://vegaprotocol.slack.com/archives/C8WS7M50E/p1635974804393800

Closes #688 