### PR TITLE
Fix/736 Align table data in validators list

### DIFF
--- a/src/routes/staking/node-list.scss
+++ b/src/routes/staking/node-list.scss
@@ -23,6 +23,7 @@
   }
 
   table {
+    max-width: 330px;
     flex: 1;
     font-size: 14px;
   }


### PR DESCRIPTION
Small CSS change to ensure table data aligns in the validators list

Closes #736 