### PR TITLE
Add "hidden" contracts route so can easily see configured contracts

### DIFF
--- a/src/routes/contracts/index.tsx
+++ b/src/routes/contracts/index.tsx
@@ -14,7 +14,7 @@ const Contracts = () => {
       {Object.entries(ADDRESSES).map(([key, value]) => (
         <div style={{ display: "flex", justifyContent: "space-between" }}>
           <div>{key}:</div>
-          <EtherscanLink address={value} chainId={chainId} />
+          <EtherscanLink address={value} chainId={chainId} text={value} />
         </div>
       ))}
     </section>

--- a/src/routes/contracts/index.tsx
+++ b/src/routes/contracts/index.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { EtherscanLink } from "../../components/etherscan-link";
+import { Heading } from "../../components/heading";
+import { ADDRESSES } from "../../config";
+import { useWeb3 } from "../../contexts/web3-context/web3-context";
+
+const Contracts = () => {
+  const { chainId } = useWeb3();
+
+  return (
+    <section>
+      <Heading title={"Contracts"} />
+      <hr />
+      {Object.entries(ADDRESSES).map(([key, value]) => (
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <div>{key}:</div>
+          <EtherscanLink address={value} chainId={chainId} />
+        </div>
+      ))}
+    </section>
+  );
+};
+
+export default Contracts;

--- a/src/routes/router-config.ts
+++ b/src/routes/router-config.ts
@@ -13,6 +13,7 @@ export const Routes = {
   LIQUIDITY: "/liquidity",
   NOT_PERMITTED: "/not-permitted",
   NOT_FOUND: "/not-found",
+  CONTRACTS: "/contracts",
 };
 
 const LazyTranches = React.lazy(
@@ -45,12 +46,19 @@ const LazyLiquidity = React.lazy(
   () =>
     import(
       /* webpackChunkName: "route-liquidity", webpackPrefetch: true */ "./liquidity"
-      )
+    )
 );
 const LazyGovernance = React.lazy(
   () =>
     import(
       /* webpackChunkName: "route-governance", webpackPrefetch: true */ "./governance"
+    )
+);
+
+const LazyContracts = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "route-tranches", webpackPrefetch: true */ "./contracts"
     )
 );
 
@@ -85,7 +93,7 @@ const routerConfig = [
   {
     path: Routes.LIQUIDITY,
     name: "DEX Liquidity",
-    component: LazyLiquidity
+    component: LazyLiquidity,
   },
   {
     path: Routes.GOVERNANCE,
@@ -99,10 +107,15 @@ const routerConfig = [
     component: NotPermitted,
   },
   {
+    path: Routes.CONTRACTS,
+    name: "Contracts",
+    component: LazyContracts,
+  },
+  {
     name: "NotFound",
     // Not lazy as loaded when a user first hits the site
     component: NotFound,
-  }
+  },
 ];
 
 export default routerConfig;


### PR DESCRIPTION
Add "hidden" contracts route so people can see the configured contracts easily, as this is currently hidden in code

[ref](https://vegaprotocol.slack.com/archives/C8WS7M50E/p1636360557458700)

![Screenshot 2021-11-08 at 08 57 15](https://user-images.githubusercontent.com/26136207/140712705-47b20e9e-864a-4799-8c8f-623135e20deb.png)

