### PR TITLE
Fix/727 transaction errors

### DIFF
--- a/src/contexts/contracts/contracts-provider.tsx
+++ b/src/contexts/contracts/contracts-provider.tsx
@@ -26,33 +26,39 @@ export const ContractsProvider = ({ children }: { children: JSX.Element }) => {
   const [contracts, setContracts] = React.useState<any>(null);
 
   React.useEffect(() => {
+    let cancelled = false;
     const run = async () => {
       const token = new VegaToken(provider, signer, ADDRESSES.vegaTokenAddress);
       const decimals = await token.decimals();
-      setContracts({
-        token,
-        staking: new StakingAbi(
-          provider,
-          signer,
-          ADDRESSES.stakingBridge,
-          decimals
-        ),
-        vesting: new VegaVesting(
-          provider,
-          signer,
-          ADDRESSES.vestingAddress,
-          decimals
-        ),
-        claim: new VegaClaim(
-          provider,
-          signer,
-          ADDRESSES.claimAddress,
-          decimals
-        ),
-      });
+      if (!cancelled) {
+        setContracts({
+          token,
+          staking: new StakingAbi(
+            provider,
+            signer,
+            ADDRESSES.stakingBridge,
+            decimals
+          ),
+          vesting: new VegaVesting(
+            provider,
+            signer,
+            ADDRESSES.vestingAddress,
+            decimals
+          ),
+          claim: new VegaClaim(
+            provider,
+            signer,
+            ADDRESSES.claimAddress,
+            decimals
+          ),
+        });
+      }
     };
 
     run();
+    return () => {
+      cancelled = true;
+    };
   }, [provider, signer]);
 
   if (!contracts) {

--- a/src/hooks/use-transaction.ts
+++ b/src/hooks/use-transaction.ts
@@ -28,6 +28,8 @@ export const useTransaction = (
       if (isUserRejection(err)) {
         dispatch({ type: TransactionActionType.TX_RESET });
         return;
+      } else {
+        Sentry.captureException(err);
       }
 
       const defaultMessage = t("Something went wrong");


### PR DESCRIPTION
Closes #727 

When we load this hook is called twice if the user is already connected:
1. With null signer
2. With JSONRPCSigner

if `const decimals = await token.decimals();` for the first took longer than the second then we end up with a null signer even though we had an instance of the contract with a signer that got discarded. We need to cancel the first one, which is done with the cancelled flag here.

In general we will need to figure out a better way of handling race conditions within async use effect hooks, as this is bound to happen gaub. Either with a generator-based cancellable primitive, a 3rd party lirbary or a better pattern. #771 raised to track this. 