### PR TITLE
use correct value

### DIFF
--- a/src/routes/staking/validator-table.tsx
+++ b/src/routes/staking/validator-table.tsx
@@ -64,7 +64,7 @@ export const ValidatorTable = ({
         </KeyValueTableRow>
         <KeyValueTableRow>
           <th>{t("STAKED BY OPERATOR")}</th>
-          <td>{node.stakedByOperator}</td>
+          <td>{node.stakedByOperatorFormatted}</td>
         </KeyValueTableRow>
         <KeyValueTableRow>
           <th>{t("STAKED BY DELEGATES")}</th>


### PR DESCRIPTION
Staked by operator value was incorrect:

![Screenshot 2021-11-12 at 13 13 07](https://user-images.githubusercontent.com/26136207/141475756-cb13174f-bef9-428e-8afe-cd7d31cd0e23.png)

it is now correct:
![Screenshot 2021-11-12 at 13 37 07](https://user-images.githubusercontent.com/26136207/141475811-6af9820a-f56b-4c32-8cf3-303b8d5bb94b.png)

