### PR TITLE
Alignment on list of validators on the staking overview page

### DIFF
--- a/src/routes/staking/node-list.scss
+++ b/src/routes/staking/node-list.scss
@@ -10,6 +10,7 @@
     word-break: break-all;
     display: flex;
     justify-content: space-between;
+    flex-direction: column;
     margin-bottom: 15px;
 
     &:last-child {
@@ -18,12 +19,11 @@
   }
 
   a {
-    max-width: 300px;
     text-decoration: none;
+    display: flex;
   }
 
   table {
-    max-width: 330px;
     flex: 1;
     font-size: 14px;
   }


### PR DESCRIPTION
Before:
<img width="658" alt="Screenshot 2021-11-15 at 11 10 07" src="https://user-images.githubusercontent.com/13255539/141772142-36c6b709-fa20-4cde-9770-de583f4bb1d9.png">

After:
<img width="657" alt="Screenshot 2021-11-15 at 11 10 13" src="https://user-images.githubusercontent.com/13255539/141772203-7793087d-b8d1-45c8-9e2c-6db8c21b2eca.png">

