### PR TITLE
Chore: Use deep partial for generate proposal func

### DIFF
--- a/src/components/graphql-provider/__mocks__/graphql-provider.tsx
+++ b/src/components/graphql-provider/__mocks__/graphql-provider.tsx
@@ -158,35 +158,26 @@ const MOCK_PARTY_DELEGATIONS: MockedResponse<PartyDelegations> = {
 };
 
 const notVoted = generateProposal({
-  // @ts-ignore
   terms: { change: { networkParameter: { key: "not.voted" } } },
-  // @ts-ignore
   party: { id: "123" },
   votes: {
-    // @ts-ignore
     yes: { votes: null },
-    // @ts-ignore
     no: { votes: null },
   },
 });
 
 const noTokens = generateProposal({
-  // @ts-ignore
   terms: { change: { networkParameter: { key: "no.tokens" } } },
 });
 
 const votedAgainst = generateProposal({
-  // @ts-ignore
   terms: { change: { networkParameter: { key: "voted.against" } } },
-  // @ts-ignore
   party: { id: "123" },
   votes: {
     no: {
       votes: [
         {
-          // @ts-ignore
           value: VoteValue.No,
-          // @ts-ignore
           party: {
             id: "0680ffba6c2e0239ebaa2b941ee79675dd1f447ddcae37720f8f377101f46527",
           },
@@ -198,21 +189,16 @@ const votedAgainst = generateProposal({
 });
 
 const didNotVote = generateProposal({
-  // @ts-ignore
   terms: { change: { networkParameter: { key: "voted.closed.did.not.vote" } } },
   state: ProposalState.Enacted,
-  // @ts-ignore
   party: { id: "123" },
 });
 
 const voteClosedVotedFor = generateProposal({
-  // @ts-ignore
   terms: { change: { networkParameter: { key: "voted.closed.voted.for" } } },
   state: ProposalState.Enacted,
-  // @ts-ignore
   party: { id: "123" },
   votes: {
-    // @ts-ignore
     yes: {
       votes: [
         {

--- a/src/lib/type-helpers.ts
+++ b/src/lib/type-helpers.ts
@@ -1,0 +1,3 @@
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};

--- a/src/routes/governance/test-helpers/generate-proposals.ts
+++ b/src/routes/governance/test-helpers/generate-proposals.ts
@@ -1,13 +1,14 @@
 import merge from "lodash/merge";
 import * as faker from "faker";
 
-import { Proposals_proposals } from "../__generated__/Proposals";
 import { ProposalState, VoteValue } from "../../../__generated__/globalTypes";
+import { ProposalFields } from "../__generated__/ProposalFields";
+import { DeepPartial } from "../../../lib/type-helpers";
 
 export function generateProposal(
-  override?: Partial<Proposals_proposals>
-): Proposals_proposals {
-  const defaultProposal = {
+  override: DeepPartial<ProposalFields> = {}
+): ProposalFields {
+  const defaultProposal: ProposalFields = {
     __typename: "Proposal",
     id: faker.datatype.uuid(),
     reference: "ref" + faker.datatype.uuid(),
@@ -25,7 +26,7 @@ export function generateProposal(
       change: {
         networkParameter: {
           key: faker.lorem.words(),
-          value: faker.datatype.number({ min: 0, max: 100 }),
+          value: faker.datatype.number({ min: 0, max: 100 }).toString(),
           __typename: "NetworkParameter",
         },
         __typename: "UpdateNetworkParameter",
@@ -57,5 +58,9 @@ export function generateProposal(
       },
     },
   };
-  return merge(defaultProposal, override);
+
+  return merge<ProposalFields, DeepPartial<ProposalFields>>(
+    defaultProposal,
+    override
+  );
 }


### PR DESCRIPTION
Some cypress tests were failing do to incorrect mock queries. I've changed the types here to allow removal of ts-ignore statements used when passing data to the generateProposal function. This should in turn protect us from putting incorrect fields into mock queries.