### PR TITLE
Fix/673 remove copy to clipboard for etherscan links

### DIFF
--- a/src/components/etherscan-link/etherscan-link.scss
+++ b/src/components/etherscan-link/etherscan-link.scss
@@ -2,10 +2,6 @@
 @import "../../styles/fonts";
 
 .etherscan-link {
-  &__mono {
-    font-family: $font-mono;
-  }
-
   &__copy-to-clipboard {
     border: 1px solid $white;
     border-radius: 0;
@@ -23,4 +19,3 @@
     }
   }
 }
-

--- a/src/components/etherscan-link/etherscan-link.tsx
+++ b/src/components/etherscan-link/etherscan-link.tsx
@@ -18,6 +18,7 @@ const etherscanUrls: Record<EthereumChainId, string> = {
 interface BaseEtherscanLinkProps {
   text?: string;
   copyToClipboard?: CopyToClipboardType;
+  className?: string;
 }
 
 interface EtherscanAddressLinkProps extends BaseEtherscanLinkProps {
@@ -43,12 +44,13 @@ export enum CopyToClipboardType {
  */
 export const EtherscanLink = ({
   text,
+  className,
   copyToClipboard = CopyToClipboardType.NONE,
   ...props
 }: EtherscanLinkProps) => {
   const { chainId } = useWeb3();
   let hash: string;
-  let txLink: string | null;
+  let href: string | null;
   const { t } = useTranslation();
   const { copy, copied } = useCopyToClipboard();
   const linkText = text ? text : t("View on Etherscan (opens in a new tab)");
@@ -56,14 +58,14 @@ export const EtherscanLink = ({
 
   if ("tx" in props) {
     hash = props.tx;
-    txLink = createLink ? createLink.tx(hash) : null;
+    href = createLink ? createLink.tx(hash) : null;
   } else {
     hash = props.address;
-    txLink = createLink ? createLink.address(hash) : null;
+    href = createLink ? createLink.address(hash) : null;
   }
 
-  // Fallback: just render the TX id
-  if (!txLink) {
+  // Fallback: just render the address/txHash
+  if (!href) {
     return <span>{hash}</span>;
   }
 
@@ -72,7 +74,7 @@ export const EtherscanLink = ({
       case CopyToClipboardType.TEXT:
         return linkText;
       case CopyToClipboardType.LINK:
-        return txLink || hash || "";
+        return href || hash || "";
       default:
         return "";
     }
@@ -91,20 +93,23 @@ export const EtherscanLink = ({
     );
   };
 
+  const linkProps = {
+    target: "_blank",
+    rel: "noreferrer",
+    href,
+    className,
+  };
+
   return copyToClipboard !== CopyToClipboardType.NONE ? (
     <Popover
       hoverOpenDelay={500}
       interactionKind={PopoverInteractionKind.HOVER}
     >
-      <a href={txLink} target="_blank" rel="noreferrer">
-        {linkText}
-      </a>
+      <a {...linkProps}>{linkText}</a>
       {getContents()}
     </Popover>
   ) : (
-    <a href={txLink} target="_blank" rel="noreferrer">
-      {linkText}
-    </a>
+    <a {...linkProps}>{linkText}</a>
   );
 };
 

--- a/src/components/etherscan-link/etherscan-link.tsx
+++ b/src/components/etherscan-link/etherscan-link.tsx
@@ -43,7 +43,7 @@ export enum CopyToClipboardType {
  */
 export const EtherscanLink = ({
   text,
-  copyToClipboard = CopyToClipboardType.TEXT,
+  copyToClipboard = CopyToClipboardType.NONE,
   ...props
 }: EtherscanLinkProps) => {
   const { chainId } = useWeb3();
@@ -91,21 +91,18 @@ export const EtherscanLink = ({
     );
   };
 
-  const linkClassName =
-    copyToClipboard === CopyToClipboardType.LINK ? "" : "etherscan-link__mono";
-
   return copyToClipboard !== CopyToClipboardType.NONE ? (
     <Popover
       hoverOpenDelay={500}
       interactionKind={PopoverInteractionKind.HOVER}
     >
-      <a href={txLink} target="_blank" rel="noreferrer" className={linkClassName}>
+      <a href={txLink} target="_blank" rel="noreferrer">
         {linkText}
       </a>
       {getContents()}
     </Popover>
   ) : (
-    <a href={txLink} target="_blank" rel="noreferrer" className={linkClassName}>
+    <a href={txLink} target="_blank" rel="noreferrer">
       {linkText}
     </a>
   );
@@ -128,4 +125,4 @@ function etherscanLinkCreator(chainId: EthereumChainId | null) {
   };
 }
 
-EtherscanLink.displayName = "EtherScanLink";
+EtherscanLink.displayName = "EtherscanLink";

--- a/src/components/transaction-callout/transaction-complete.tsx
+++ b/src/components/transaction-callout/transaction-complete.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Callout } from "../callout";
 import { EtherscanLink } from "../etherscan-link";
-import { CopyToClipboardType } from "../etherscan-link/etherscan-link";
 import { Tick } from "../icons";
 
 export const TransactionComplete = ({

--- a/src/components/transaction-callout/transaction-complete.tsx
+++ b/src/components/transaction-callout/transaction-complete.tsx
@@ -20,8 +20,9 @@ export const TransactionComplete = ({
     <Callout icon={<Tick />} intent="success" title={heading || t("Complete")}>
       {body && <p data-testid="transaction-complete-body">{body}</p>}
       <p>
-        <EtherscanLink tx={hash} copyToClipboard={CopyToClipboardType.LINK} />
+        <EtherscanLink tx={hash} />
       </p>
+      LINK
       {footer && <p data-testid="transaction-complete-footer">{footer}</p>}
     </Callout>
   );

--- a/src/components/transaction-callout/transaction-error.tsx
+++ b/src/components/transaction-callout/transaction-error.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Callout } from "../callout";
 import { EtherscanLink } from "../etherscan-link";
-import { CopyToClipboardType } from "../etherscan-link/etherscan-link";
 import { Error } from "../icons";
 
 export interface TransactionErrorProps {

--- a/src/components/transaction-callout/transaction-error.tsx
+++ b/src/components/transaction-callout/transaction-error.tsx
@@ -22,7 +22,7 @@ export const TransactionError = ({
       <p>{error ? error.message : t("Something went wrong")}</p>
       {hash ? (
         <p>
-          <EtherscanLink tx={hash} copyToClipboard={CopyToClipboardType.LINK} />
+          <EtherscanLink tx={hash} />
         </p>
       ) : null}
       <button onClick={() => onActionClick()}>{t("Try again")}</button>

--- a/src/components/transaction-callout/transaction-pending.tsx
+++ b/src/components/transaction-callout/transaction-pending.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Callout } from "../callout";
 import { EtherscanLink } from "../etherscan-link";
-import { CopyToClipboardType } from "../etherscan-link/etherscan-link";
 import { Loader } from "../loader";
 
 export const TransactionPending = ({
@@ -40,7 +39,7 @@ export const TransactionPending = ({
     <Callout icon={<Loader />} title={title}>
       {body && <p data-testid="transaction-pending-body">{body}</p>}
       <p>
-        <EtherscanLink tx={hash} copyToClipboard={CopyToClipboardType.LINK} />
+        <EtherscanLink tx={hash} />
       </p>
       {footer && <p data-testid="transaction-pending-footer">{footer}</p>}
     </Callout>

--- a/src/routes/contracts/index.tsx
+++ b/src/routes/contracts/index.tsx
@@ -16,6 +16,7 @@ const Contracts = () => {
             address={value}
             text={value}
             copyToClipboard={CopyToClipboardType.LINK}
+            className="font-mono"
           />
         </div>
       ))}

--- a/src/routes/contracts/index.tsx
+++ b/src/routes/contracts/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { EtherscanLink } from "../../components/etherscan-link";
+import { CopyToClipboardType } from "../../components/etherscan-link/etherscan-link";
 import { Heading } from "../../components/heading";
 import { ADDRESSES } from "../../config";
 
@@ -11,7 +12,11 @@ const Contracts = () => {
       {Object.entries(ADDRESSES).map(([key, value]) => (
         <div style={{ display: "flex", justifyContent: "space-between" }}>
           <div>{key}:</div>
-          <EtherscanLink address={value} text={value} />
+          <EtherscanLink
+            address={value}
+            text={value}
+            copyToClipboard={CopyToClipboardType.LINK}
+          />
         </div>
       ))}
     </section>

--- a/src/routes/home/token-details/token-details.tsx
+++ b/src/routes/home/token-details/token-details.tsx
@@ -12,6 +12,7 @@ import { TokenDetailsCirculating } from "./token-details-circulating";
 import { formatNumber } from "../../../lib/format-number";
 import { useTranslation } from "react-i18next";
 import { useTranches } from "../../../hooks/use-tranches";
+import { CopyToClipboardType } from "../../../components/etherscan-link/etherscan-link";
 
 export const TokenDetails = ({
   totalSupply,
@@ -31,6 +32,7 @@ export const TokenDetails = ({
           <EtherscanLink
             address={ADDRESSES.vegaTokenAddress}
             text={ADDRESSES.vegaTokenAddress}
+            copyToClipboard={CopyToClipboardType.LINK}
           />
         </td>
       </KeyValueTableRow>
@@ -40,6 +42,7 @@ export const TokenDetails = ({
           <EtherscanLink
             address={ADDRESSES.vestingAddress}
             text={ADDRESSES.vestingAddress}
+            copyToClipboard={CopyToClipboardType.LINK}
           />
         </td>
       </KeyValueTableRow>

--- a/src/routes/home/token-details/token-details.tsx
+++ b/src/routes/home/token-details/token-details.tsx
@@ -33,6 +33,7 @@ export const TokenDetails = ({
             address={ADDRESSES.vegaTokenAddress}
             text={ADDRESSES.vegaTokenAddress}
             copyToClipboard={CopyToClipboardType.LINK}
+            className="font-mono"
           />
         </td>
       </KeyValueTableRow>
@@ -43,6 +44,7 @@ export const TokenDetails = ({
             address={ADDRESSES.vestingAddress}
             text={ADDRESSES.vestingAddress}
             copyToClipboard={CopyToClipboardType.LINK}
+            className="font-mono"
           />
         </td>
       </KeyValueTableRow>

--- a/src/routes/liquidity/dex-table/dex-table.tsx
+++ b/src/routes/liquidity/dex-table/dex-table.tsx
@@ -11,6 +11,7 @@ import {
   KeyValueTableRow,
 } from "../../../components/key-value-table";
 import { formatNumber } from "../../../lib/format-number";
+import { CopyToClipboardType } from "../../../components/etherscan-link/etherscan-link";
 
 interface DexTokensSectionProps {
   name: string;
@@ -59,7 +60,11 @@ export const DexTokensSection = ({
         <KeyValueTableRow>
           <th>{t("liquidityTokenContractAddress")}</th>
           <td>
-            <EtherscanLink address={contractAddress} text={contractAddress} />
+            <EtherscanLink
+              address={contractAddress}
+              text={contractAddress}
+              copyToClipboard={CopyToClipboardType.LINK}
+            />
           </td>
         </KeyValueTableRow>
         <KeyValueTableRow>
@@ -74,6 +79,7 @@ export const DexTokensSection = ({
             <EtherscanLink
               address={values.awardContractAddress}
               text={values.awardContractAddress}
+              copyToClipboard={CopyToClipboardType.LINK}
             />
           </td>
         </KeyValueTableRow>
@@ -83,6 +89,7 @@ export const DexTokensSection = ({
             <EtherscanLink
               address={values.lpTokenContractAddress}
               text={values.lpTokenContractAddress}
+              copyToClipboard={CopyToClipboardType.LINK}
             />
           </td>
         </KeyValueTableRow>

--- a/src/routes/staking/associate/associate-transaction.tsx
+++ b/src/routes/staking/associate/associate-transaction.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Callout } from "../../../components/callout";
 import { EtherscanLink } from "../../../components/etherscan-link";
-import { CopyToClipboardType } from "../../../components/etherscan-link/etherscan-link";
 import { Loader } from "../../../components/loader";
 import { TransactionCallout } from "../../../components/transaction-callout";
 import {

--- a/src/routes/staking/associate/associate-transaction.tsx
+++ b/src/routes/staking/associate/associate-transaction.tsx
@@ -66,10 +66,7 @@ export const AssociateTransaction = ({
           })}
         </p>
         <p>
-          <EtherscanLink
-            tx={state.txData.hash!}
-            copyToClipboard={CopyToClipboardType.LINK}
-          />
+          <EtherscanLink tx={state.txData.hash!} />
         </p>
         <p data-testid="transaction-pending-footer">
           {t("pendingAssociationText", {

--- a/src/routes/staking/staking.tsx
+++ b/src/routes/staking/staking.tsx
@@ -13,6 +13,7 @@ import { Staking as StakingQueryResult } from "./__generated__/Staking";
 import { useWeb3 } from "../../contexts/web3-context/web3-context";
 import { formatNumber } from "../../lib/format-number";
 import { EtherscanLink } from "../../components/etherscan-link";
+import { CopyToClipboardType } from "../../components/etherscan-link/etherscan-link";
 
 export const Staking = ({ data }: { data?: StakingQueryResult }) => {
   const { t } = useTranslation();
@@ -55,7 +56,11 @@ export const StakingStepConnectWallets = () => {
       <Callout intent="success" icon={<Tick />} title={"Connected"}>
         <p>
           {t("Connected Ethereum address")}&nbsp;
-          <EtherscanLink address={ethAddress} text={ethAddress} />
+          <EtherscanLink
+            address={ethAddress}
+            text={ethAddress}
+            copyToClipboard={CopyToClipboardType.LINK}
+          />
         </p>
         <p>{t("stakingVegaWalletConnected", { key: currVegaKey.pub })}</p>
       </Callout>

--- a/src/routes/staking/validator-table.tsx
+++ b/src/routes/staking/validator-table.tsx
@@ -10,6 +10,7 @@ import { BigNumber } from "../../lib/bignumber";
 import { Staking_nodes } from "./__generated__/Staking";
 import { formatNumber } from "../../lib/format-number";
 import { EtherscanLink } from "../../components/etherscan-link";
+import { CopyToClipboardType } from "../../components/etherscan-link/etherscan-link";
 
 export interface ValidatorTableProps {
   node: Staking_nodes;
@@ -60,6 +61,7 @@ export const ValidatorTable = ({
             <EtherscanLink
               text={node.ethereumAdddress}
               address={node.ethereumAdddress}
+              copyToClipboard={CopyToClipboardType.LINK}
             />
           </td>
         </KeyValueTableRow>

--- a/src/routes/withdrawals/index.tsx
+++ b/src/routes/withdrawals/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "./__generated__/WithdrawalsPage";
 import { Flags } from "../../config";
 import { useRefreshBalances } from "../../hooks/use-refresh-balances";
+import { CopyToClipboardType } from "../../components/etherscan-link/etherscan-link";
 
 const Withdrawals = () => {
   const { t } = useTranslation();
@@ -215,6 +216,7 @@ export const Withdrawal = ({
               text={truncateMiddle(
                 withdrawal.details?.receiverAddress as string
               )}
+              copyToClipboard={CopyToClipboardType.LINK}
             />
           </td>
         </KeyValueTableRow>


### PR DESCRIPTION
Makes the Etherscan link not use the copy popover by default so that for transactions you just get a plain link linking directly to Etherscan. Places where we show Ethereum addresses _do_ get the popover with a link to copy.

- Makes etherscan link not use the popover to copy by default
- Adds copy popovers to places that require it

Closes #673 