### PR TITLE
readme: new screenshot, +features & remove Nolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 **_Control panel for your VEGA tokens_**
 
-![preview](https://user-images.githubusercontent.com/6678/131992372-4a89d7ea-d9b3-4698-b767-e4464396a7d0.jpg)
+<img width="1438" alt="Screenshot 2021-12-11 at 06 32 51" src="https://user-images.githubusercontent.com/13255539/145666935-563fc1ff-35bc-4cd9-ae6d-cf711cc23454.png">
 
 ## Features
 
 - View vesting progress
 - Redeem VEGA tokens
 - Stake VEGA tokens
-
-# Reporting issues
-
-If you are not on the Vega team and found an issue on token.vega.xyz, please report your bug on our [Nolt board](https://vega-testnet.nolt.io). Include as much information as possible, including screenshots and Etherscan links. Issues raised via this repository may be closed without investigation.
+- Withdraw tokens
+- Vote on proposals
 
 # Development
 


### PR DESCRIPTION
- up to date preview image

<img width="1438" alt="Screenshot 2021-12-11 at 06 32 51" src="https://user-images.githubusercontent.com/13255539/145667032-6050b4fa-11c7-4da6-9659-36a5daaa6d99.png">

- added governance and withdraws to features list
- removed reference to "Vega team" and Nolt.