### PR TITLE
Fezt/1074 Splash screen for network down

### DIFF
--- a/src/app-loader.tsx
+++ b/src/app-loader.tsx
@@ -13,6 +13,8 @@ import {
 import { useContracts } from "./contexts/contracts/contracts-context";
 import { useRefreshAssociatedBalances } from "./hooks/use-refresh-associated-balances";
 import { useWeb3 } from "./contexts/web3-context/web3-context";
+import { Flags } from "./config";
+import { SplashError } from "./components/splash-error";
 
 export const AppLoader = ({ children }: { children: React.ReactElement }) => {
   const { ethAddress } = useWeb3();
@@ -52,7 +54,9 @@ export const AppLoader = ({ children }: { children: React.ReactElement }) => {
       }
     };
 
-    run();
+    if (!Flags.NETWORK_DOWN) {
+      run();
+    }
   }, [token, appDispatch, staking, vesting]);
 
   // Attempte to get vega keys on startup
@@ -90,8 +94,18 @@ export const AppLoader = ({ children }: { children: React.ReactElement }) => {
       });
     }
 
-    run();
+    if (!Flags.NETWORK_DOWN) {
+      run();
+    }
   }, [appDispatch, ethAddress, vegaKeysLoaded, setAssociatedBalances]);
+
+  if (Flags.NETWORK_DOWN) {
+    return (
+      <SplashScreen>
+        <SplashError />
+      </SplashScreen>
+    );
+  }
 
   if (!loaded) {
     return (

--- a/src/components/splash-error/index.ts
+++ b/src/components/splash-error/index.ts
@@ -1,0 +1,1 @@
+export * from "./splash-error";

--- a/src/components/splash-error/splash-error.scss
+++ b/src/components/splash-error/splash-error.scss
@@ -1,0 +1,23 @@
+@import "../../styles/colors";
+
+.splash-error__icon {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 20px;
+
+  span {
+    display: block;
+    width: 10px;
+    background: $white;
+
+    &:first-child {
+      height: 30px;
+    }
+
+    &:last-child {
+      height: 10px;
+    }
+  }
+}

--- a/src/components/splash-error/splash-error.tsx
+++ b/src/components/splash-error/splash-error.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from "react-i18next";
+import "./splash-error.scss";
+
+export const SplashError = () => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <div className="splash-error__icon">
+        <span />
+        <span />
+      </div>
+      {t("networkDown")}
+    </div>
+  );
+};

--- a/src/components/splash-loader/splash-loader.scss
+++ b/src/components/splash-loader/splash-loader.scss
@@ -19,9 +19,4 @@
       opacity: 0;
     }
   }
-
-  &__text {
-    font-size: 20px;
-    color: $white;
-  }
 }

--- a/src/components/splash-loader/splash-loader.tsx
+++ b/src/components/splash-loader/splash-loader.tsx
@@ -25,7 +25,7 @@ export const SplashLoader = ({ text = "Loading" }: { text?: string }) => {
           );
         })}
       </div>
-      <div className="loading__text">{text}</div>
+      <div>{text}</div>
     </div>
   );
 };

--- a/src/components/splash-screen/splash-screen.scss
+++ b/src/components/splash-screen/splash-screen.scss
@@ -1,0 +1,12 @@
+@import "../../styles/colors";
+
+.splash-screen {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  width: 100%;
+  height: 100%;
+  font-size: 20px;
+  color: $white;
+}

--- a/src/components/splash-screen/splash-screen.tsx
+++ b/src/components/splash-screen/splash-screen.tsx
@@ -1,18 +1,6 @@
+import "./splash-screen.scss";
 import React from "react";
 
 export const SplashScreen = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        textAlign: "center",
-      }}
-    >
-      {children}
-    </div>
-  );
+  return <div className="splash-screen">{children}</div>;
 };

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -1,6 +1,7 @@
 const TRUTHY = ["1", "true"];
 
 export const Flags = {
+  NETWORK_DOWN: TRUTHY.includes(process.env.REACT_APP_NETWORK_DOWN!),
   HOSTED_WALLET_ENABLED: TRUTHY.includes(
     process.env.REACT_APP_HOSTED_WALLET_ENABLED!
   ),

--- a/src/i18n/translations/dev.json
+++ b/src/i18n/translations/dev.json
@@ -483,5 +483,6 @@
   "Signature": "Signature",
   "voteFailedReason": "Vote closed. Failed due to: ",
   "votePassed": "Vote passed.",
-  "subjectToFurtherActions": "Vote passed {{daysAgo}} subject to further actions."
+  "subjectToFurtherActions": "Vote passed {{daysAgo}} subject to further actions.",
+  "networkDown": "This site is not currently connecting to the network please try again later."
 }


### PR DESCRIPTION
- Adds REACT_APP_NETWORK_DOWN flag
- Doesn't run startup wallet and ethereum queries if network down flag is set
- Renders a splash screen error state if flag is set
- Sets splash screen text size in parent spalsh screen component so same styles are used for both error and loading states