### PR TITLE
Change feedback links from nolt to GitHub discussions in TFE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 Thanks for wanting to contribute to Vega's token front-end site.
 
-We are not currently accepting bug reports and issues from the community on this repository. If you'd like to report an issue, please visit our [Nolt board](https://vega-testnet.nolt.io) and include as much information as possible, including screenshots and Etherscan links. We really appreciate your interest in helping improve all facets of Vega!
+We are not currently accepting bug reports and issues from the community on this repository. If you'd like to report an issue, please visit our [Feedback board](https://github.com/vegaprotocol/feedback/discussions) and include as much information as possible, including screenshots and Etherscan links. We really appreciate your interest in helping improve all facets of Vega!

--- a/src/components/app-footer/app-footer.tsx
+++ b/src/components/app-footer/app-footer.tsx
@@ -13,7 +13,7 @@ export const AppFooter = () => {
           i18nKey="footerLinksText"
           components={{
             /* eslint-disable */
-            noltLink: <a href={Links.NOLT} />,
+            feedbackLink: <a href={Links.FEEDBACK} />,
             githubLink: <a href={Links.GITHUB} />,
             /* eslint-enable */
           }}

--- a/src/config/links.ts
+++ b/src/config/links.ts
@@ -1,13 +1,13 @@
 export const Links = {
-  WALLET_RELEASES: "https://github.com/vegaprotocol/go-wallet/releases",
+  WALLET_RELEASES: "https://github.com/vegaprotocol/vegawallet-desktop/releases",
   WALLET_GUIDE:
-    "https://docs.vega.xyz/docs/tools/vega-wallet/cli-wallet/create-wallet",
+    "https://docs.vega.xyz/docs/tools/vega-wallet",
   SUSHI_PAIRS: "https://analytics.sushi.com/pairs/",
   SUSHI_ONSEN_MENU: "https://app.sushi.com/farm",
   SUSHI_ONSEN_WHAT_IS:
     "https://docs.sushi.com/products/yield-farming/what-is-onsen",
   SUSHI_ONSEN_FAQ: "https://docs.sushi.com/faq-1/onsen-faq",
-  NOLT: "https://vega-testnet.nolt.io",
+  FEEDBACK: "https://github.com/vegaprotocol/feedback/discussions",
   GITHUB: "https://github.com/vegaprotocol/token-frontend",
   DISCORD: "https://vega.xyz/discord",
   STAKING_GUIDE:

--- a/src/i18n/translations/dev.json
+++ b/src/i18n/translations/dev.json
@@ -471,7 +471,7 @@
   "vegaWallet": "Vega Wallet",
   "rewardsComingSoon": "Rewards is coming soon",
   "associationChoice": "You have $VEGA tokens held by the vesting contract. Would you like to associate those or associate $VEGA directly from your wallet?",
-  "footerLinksText": "Known issues and feedback on <noltLink>Nolt</noltLink> and <githubLink>Github</githubLink>",
+  "footerLinksText": "Known issues and feedback on the <feedbackLink>Feedback board</feedbackLink> and <githubLink>Github</githubLink>",
   "connectEthWallet": "Connect Ethereum wallet",
   "connectEthWalletToAssociate": "Connect Ethereum wallet to associate $VEGA",
   "connectVegaWallet": "Connect Vega wallet",


### PR DESCRIPTION
With the introduction of the feedback repo and the discussion page this PR updates all the links on the token dapp to point to the new link

removed:
https://vega-testnet.nolt.io/

added:
https://github.com/vegaprotocol/feedback/discussions

This PR also changes the wallet links. 
